### PR TITLE
Implement CGAP_KEYS_FILE (C4-403)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ Change Log
 ----------
 
 
+0.4.2
+=====
+
+**PR 5: Implement CGAP_KEYS_FILE**
+
+* Fix environment variable ``CGAP_KEYS_FILE`` to allow override of what file contains the user's keys.  This is intended only for internal use, not for end users, which is why it's not an argument to the relevant commands.
+
 0.4.1
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "submit_cgap"
-version = "0.4.1"
+version = "0.4.2"
 description = "Support for uploading file submissions to the Clinical Genomics Analysis Platform (CGAP)."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/submit_cgap/base.py
+++ b/submit_cgap/base.py
@@ -1,4 +1,5 @@
 import contextlib
+import functools
 import os
 
 from dcicutils.qa_utils import local_attrs
@@ -45,3 +46,11 @@ class KeyManager:
         filename = os.environ.get('CGAP_KEYS_FILE') or None  # Treats empty string as undefined
         with cls.alternate_keydicts_filename(filename=filename):
             yield
+
+
+def UsingCGAPKeysFile(fn):
+    @functools.wraps(fn)
+    def wrapped(*args, **kwargs):
+        with KeyManager.alternate_keydicts_filename_from_environ():
+            return fn(*args, **kwargs)
+    return wrapped

--- a/submit_cgap/base.py
+++ b/submit_cgap/base.py
@@ -25,7 +25,10 @@ DEFAULT_ENV = _compute_default_env()
 
 class KeyManager:
 
-    _KEYDICTS_FILENAME = os.path.expanduser('~/.cgap-keys.json')
+    # This is not necessarily the actual keydicts filename. It can e overridden by environment variable CGAP_KEYS_FILE
+    DEFAULT_KEYDICTS_FILENAME = os.path.expanduser('~/.cgap-keys.json')
+
+    _KEYDICTS_FILENAME = DEFAULT_KEYDICTS_FILENAME
 
     @classmethod
     def keydicts_filename(cls):

--- a/submit_cgap/scripts/resume_uploads.py
+++ b/submit_cgap/scripts/resume_uploads.py
@@ -1,10 +1,12 @@
 import argparse
 from ..submission import resume_uploads
+from ..base import UsingCGAPKeysFile
 
 
 EPILOG = __doc__
 
 
+@UsingCGAPKeysFile
 def main(simulated_args_for_testing=None):
     parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Submits a data bundle part",

--- a/submit_cgap/scripts/show_upload_info.py
+++ b/submit_cgap/scripts/show_upload_info.py
@@ -1,10 +1,12 @@
 import argparse
 from ..submission import show_upload_info
+from ..base import UsingCGAPKeysFile
 
 
 EPILOG = __doc__
 
 
+@UsingCGAPKeysFile
 def main(simulated_args_for_testing=None):
     parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Submits a data bundle part",

--- a/submit_cgap/scripts/submit_metadata_bundle.py
+++ b/submit_cgap/scripts/submit_metadata_bundle.py
@@ -1,10 +1,12 @@
 import argparse
 from ..submission import submit_metadata_bundle
+from ..base import UsingCGAPKeysFile
 
 
 EPILOG = __doc__
 
 
+@UsingCGAPKeysFile
 def main(simulated_args_for_testing=None):
     parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Submits a data bundle",

--- a/submit_cgap/scripts/upload_item_data.py
+++ b/submit_cgap/scripts/upload_item_data.py
@@ -1,10 +1,12 @@
 import argparse
 from ..submission import upload_item_data
+from ..base import UsingCGAPKeysFile
 
 
 EPILOG = __doc__
 
 
+@UsingCGAPKeysFile
 def main(simulated_args_for_testing=None):
     parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Submits a data bundle part",

--- a/submit_cgap/tests/test_resume_uploads.py
+++ b/submit_cgap/tests/test_resume_uploads.py
@@ -1,5 +1,6 @@
 import pytest
 
+from dcicutils.misc_utils import ignored
 from dcicutils.qa_utils import override_environ
 from unittest import mock
 from ..base import KeyManager
@@ -21,11 +22,14 @@ def test_resume_uploads_script(keyfile):
                         # but inside the call, because of a decorator, the default might be different.
                         # See additional test below.
                         assert KeyManager.keydicts_filename() == KeyManager.DEFAULT_KEYDICTS_FILENAME
+
                         def mocked_resume_uploads(*args, **kwargs):
+                            ignored(args, kwargs)
                             # We don't need to test this function's actions because we test its call args below.
                             # However, we do need to run this one test from the same dynamic context,
                             # so this is close enough.
                             assert KeyManager.keydicts_filename() == (keyfile or KeyManager.DEFAULT_KEYDICTS_FILENAME)
+
                         mock_resume_uploads.side_effect = mocked_resume_uploads
                         resume_uploads_main(args_in)
                         mock_resume_uploads.assert_called_with(**expect_call_args)

--- a/submit_cgap/tests/test_resume_uploads.py
+++ b/submit_cgap/tests/test_resume_uploads.py
@@ -12,17 +12,27 @@ def test_resume_uploads_script(keyfile):
 
     def test_it(args_in, expect_exit_code, expect_called, expect_call_args=None):
         output = []
-        with mock.patch.object(resume_uploads_module, "print") as mock_print:
-            mock_print.side_effect = lambda *args: output.append(" ".join(args))
-            with mock.patch.object(resume_uploads_module, "resume_uploads") as mock_resume_uploads:
-                try:
-                    assert KeyManager.keydicts_filename() == keyfile or KeyManager.DEFAULT_KEYDICTS_FILENAME
-                    resume_uploads_main(args_in)
-                    mock_resume_uploads.assert_called_with(**expect_call_args)
-                except SystemExit as e:
-                    assert e.code == expect_exit_code
-                assert mock_resume_uploads.call_count == (1 if expect_called else 0)
-                assert output == []
+        with override_environ(CGAP_KEYS_FILE=keyfile):
+            with mock.patch.object(resume_uploads_module, "print") as mock_print:
+                mock_print.side_effect = lambda *args: output.append(" ".join(args))
+                with mock.patch.object(resume_uploads_module, "resume_uploads") as mock_resume_uploads:
+                    try:
+                        # Outside of the call, we will always see the default filename for cgap keys
+                        # but inside the call, because of a decorator, the default might be different.
+                        # See additional test below.
+                        assert KeyManager.keydicts_filename() == KeyManager.DEFAULT_KEYDICTS_FILENAME
+                        def mocked_resume_uploads(*args, **kwargs):
+                            # We need to test this function because we test its call args below.
+                            # However, we do need to run this one test from the same dynamic context,
+                            # so this is close enough.
+                            assert KeyManager.keydicts_filename() == (keyfile or KeyManager.DEFAULT_KEYDICTS_FILENAME)
+                        mock_resume_uploads.side_effect = mocked_resume_uploads
+                        resume_uploads_main(args_in)
+                        mock_resume_uploads.assert_called_with(**expect_call_args)
+                    except SystemExit as e:
+                        assert e.code == expect_exit_code
+                    assert mock_resume_uploads.call_count == (1 if expect_called else 0)
+                    assert output == []
 
     test_it(args_in=[], expect_exit_code=2, expect_called=False)  # Missing args
     test_it(args_in=['some-guid'], expect_exit_code=0, expect_called=True, expect_call_args={

--- a/submit_cgap/tests/test_resume_uploads.py
+++ b/submit_cgap/tests/test_resume_uploads.py
@@ -1,9 +1,14 @@
+import pytest
+
+from dcicutils.qa_utils import override_environ
 from unittest import mock
+from ..base import KeyManager
 from ..scripts.resume_uploads import main as resume_uploads_main
 from ..scripts import resume_uploads as resume_uploads_module
 
 
-def test_resume_uploads_script():
+@pytest.mark.parametrize("keyfile", [None, "foo.bar"])
+def test_resume_uploads_script(keyfile):
 
     def test_it(args_in, expect_exit_code, expect_called, expect_call_args=None):
         output = []
@@ -11,6 +16,7 @@ def test_resume_uploads_script():
             mock_print.side_effect = lambda *args: output.append(" ".join(args))
             with mock.patch.object(resume_uploads_module, "resume_uploads") as mock_resume_uploads:
                 try:
+                    assert KeyManager.keydicts_filename() == keyfile or KeyManager.DEFAULT_KEYDICTS_FILENAME
                     resume_uploads_main(args_in)
                     mock_resume_uploads.assert_called_with(**expect_call_args)
                 except SystemExit as e:

--- a/submit_cgap/tests/test_resume_uploads.py
+++ b/submit_cgap/tests/test_resume_uploads.py
@@ -22,7 +22,7 @@ def test_resume_uploads_script(keyfile):
                         # See additional test below.
                         assert KeyManager.keydicts_filename() == KeyManager.DEFAULT_KEYDICTS_FILENAME
                         def mocked_resume_uploads(*args, **kwargs):
-                            # We need to test this function because we test its call args below.
+                            # We don't need to test this function's actions because we test its call args below.
                             # However, we do need to run this one test from the same dynamic context,
                             # so this is close enough.
                             assert KeyManager.keydicts_filename() == (keyfile or KeyManager.DEFAULT_KEYDICTS_FILENAME)

--- a/submit_cgap/tests/test_show_upload_info.py
+++ b/submit_cgap/tests/test_show_upload_info.py
@@ -22,7 +22,7 @@ def test_show_upload_info_script(keyfile):
                         # See additional test below.
                         assert KeyManager.keydicts_filename() == KeyManager.DEFAULT_KEYDICTS_FILENAME
                         def mocked_show_upload_info(*args, **kwargs):
-                            # We need to test this function because we test its call args below.
+                            # We don't need to test this function's actions because we test its call args below.
                             # However, we do need to run this one test from the same dynamic context,
                             # so this is close enough.
                             assert KeyManager.keydicts_filename() == (keyfile or KeyManager.DEFAULT_KEYDICTS_FILENAME)

--- a/submit_cgap/tests/test_show_upload_info.py
+++ b/submit_cgap/tests/test_show_upload_info.py
@@ -1,9 +1,14 @@
+import pytest
+
+from dcicutils.qa_utils import override_environ
 from unittest import mock
+from ..base import KeyManager
 from ..scripts.show_upload_info import main as show_upload_info_main
 from ..scripts import show_upload_info as show_upload_info_module
 
 
-def test_show_upload_info_script():
+@pytest.mark.parametrize("keyfile", [None, "foo.bar"])
+def test_show_upload_info_script(keyfile):
 
     def test_it(args_in, expect_exit_code, expect_called, expect_call_args=None):
         output = []
@@ -11,6 +16,7 @@ def test_show_upload_info_script():
             mock_print.side_effect = lambda *args: output.append(" ".join(args))
             with mock.patch.object(show_upload_info_module, "show_upload_info") as mock_show_upload_info:
                 try:
+                    assert KeyManager.keydicts_filename() == keyfile or KeyManager.DEFAULT_KEYDICTS_FILENAME
                     show_upload_info_main(args_in)
                     mock_show_upload_info.assert_called_with(**expect_call_args)
                 except SystemExit as e:

--- a/submit_cgap/tests/test_show_upload_info.py
+++ b/submit_cgap/tests/test_show_upload_info.py
@@ -1,5 +1,6 @@
 import pytest
 
+from dcicutils.misc_utils import ignored
 from dcicutils.qa_utils import override_environ
 from unittest import mock
 from ..base import KeyManager
@@ -21,11 +22,14 @@ def test_show_upload_info_script(keyfile):
                         # but inside the call, because of a decorator, the default might be different.
                         # See additional test below.
                         assert KeyManager.keydicts_filename() == KeyManager.DEFAULT_KEYDICTS_FILENAME
+
                         def mocked_show_upload_info(*args, **kwargs):
+                            ignored(args, kwargs)
                             # We don't need to test this function's actions because we test its call args below.
                             # However, we do need to run this one test from the same dynamic context,
                             # so this is close enough.
                             assert KeyManager.keydicts_filename() == (keyfile or KeyManager.DEFAULT_KEYDICTS_FILENAME)
+
                         mock_show_upload_info.side_effect = mocked_show_upload_info
                         show_upload_info_main(args_in)
                         mock_show_upload_info.assert_called_with(**expect_call_args)

--- a/submit_cgap/tests/test_submit_metadata_bundle.py
+++ b/submit_cgap/tests/test_submit_metadata_bundle.py
@@ -1,19 +1,27 @@
+import pytest
+
+from dcicutils.qa_utils import override_environ
 from unittest import mock
+from ..base import KeyManager
 from ..scripts.submit_metadata_bundle import main as submit_metadata_bundle_main
 from ..scripts import submit_metadata_bundle as submit_metadata_bundle_module
 
 
-def test_submit_metadata_bundle_script():
+@pytest.mark.parametrize("keyfile", [None, "foo.bar"])
+def test_submit_metadata_bundle_script(keyfile):
 
     def test_it(args_in, expect_exit_code, expect_called, expect_call_args=None):
-        with mock.patch.object(submit_metadata_bundle_module,
-                               "submit_metadata_bundle") as mock_submit_metadata_bundle:
-            try:
-                submit_metadata_bundle_main(args_in)
-                mock_submit_metadata_bundle.assert_called_with(**expect_call_args)
-            except SystemExit as e:
-                assert e.code == expect_exit_code
-            assert mock_submit_metadata_bundle.call_count == (1 if expect_called else 0)
+
+        with override_environ(CGAP_KEYS_FILE=keyfile):
+            with mock.patch.object(submit_metadata_bundle_module,
+                                   "submit_metadata_bundle") as mock_submit_metadata_bundle:
+                try:
+                    assert KeyManager.keydicts_filename() == keyfile or KeyManager.DEFAULT_KEYDICTS_FILENAME
+                    submit_metadata_bundle_main(args_in)
+                    mock_submit_metadata_bundle.assert_called_with(**expect_call_args)
+                except SystemExit as e:
+                    assert e.code == expect_exit_code
+                assert mock_submit_metadata_bundle.call_count == (1 if expect_called else 0)
 
     test_it(args_in=[], expect_exit_code=2, expect_called=False)  # Missing args
     test_it(args_in=['some-file'], expect_exit_code=0, expect_called=True, expect_call_args={

--- a/submit_cgap/tests/test_submit_metadata_bundle.py
+++ b/submit_cgap/tests/test_submit_metadata_bundle.py
@@ -1,5 +1,6 @@
 import pytest
 
+from dcicutils.misc_utils import ignored
 from dcicutils.qa_utils import override_environ
 from unittest import mock
 from ..base import KeyManager
@@ -20,11 +21,14 @@ def test_submit_metadata_bundle_script(keyfile):
                     # but inside the call, because of a decorator, the default might be different.
                     # See additional test below.
                     assert KeyManager.keydicts_filename() == KeyManager.DEFAULT_KEYDICTS_FILENAME
+
                     def mocked_submit_metadata_bundle(*args, **kwargs):
+                        ignored(args, kwargs)
                         # We don't need to test this function's actionsusin because we test its call args below.
                         # However, we do need to run this one test from the same dynamic context,
                         # so this is close enough.
                         assert KeyManager.keydicts_filename() == (keyfile or KeyManager.DEFAULT_KEYDICTS_FILENAME)
+
                     mock_submit_metadata_bundle.side_effect = mocked_submit_metadata_bundle
                     submit_metadata_bundle_main(args_in)
                     mock_submit_metadata_bundle.assert_called_with(**expect_call_args)

--- a/submit_cgap/tests/test_submit_metadata_bundle.py
+++ b/submit_cgap/tests/test_submit_metadata_bundle.py
@@ -21,7 +21,7 @@ def test_submit_metadata_bundle_script(keyfile):
                     # See additional test below.
                     assert KeyManager.keydicts_filename() == KeyManager.DEFAULT_KEYDICTS_FILENAME
                     def mocked_submit_metadata_bundle(*args, **kwargs):
-                        # We need to test this function because we test its call args below.
+                        # We don't need to test this function's actionsusin because we test its call args below.
                         # However, we do need to run this one test from the same dynamic context,
                         # so this is close enough.
                         assert KeyManager.keydicts_filename() == (keyfile or KeyManager.DEFAULT_KEYDICTS_FILENAME)

--- a/submit_cgap/tests/test_upload_item_data.py
+++ b/submit_cgap/tests/test_upload_item_data.py
@@ -21,7 +21,7 @@ def test_upload_item_data_script(keyfile):
                     # See additional test below.
                     assert KeyManager.keydicts_filename() == KeyManager.DEFAULT_KEYDICTS_FILENAME
                     def mocked_upload_item_data(*args, **kwargs):
-                        # We need to test this function because we test its call args below.
+                        # We don't need to test this function's actions because we test its call args below.
                         # However, we do need to run this one test from the same dynamic context,
                         # so this is close enough.
                         assert KeyManager.keydicts_filename() == (keyfile or KeyManager.DEFAULT_KEYDICTS_FILENAME)

--- a/submit_cgap/tests/test_upload_item_data.py
+++ b/submit_cgap/tests/test_upload_item_data.py
@@ -1,14 +1,20 @@
+import pytest
+
+from dcicutils.qa_utils import override_environ
 from unittest import mock
+from ..base import KeyManager
 from ..scripts.upload_item_data import main as upload_item_data_main
 from ..scripts import upload_item_data as upload_item_data_module
 
 
-def test_upload_item_data_script():
+@pytest.mark.parametrize("keyfile", [None, "foo.bar"])
+def test_upload_item_data_script(keyfile):
 
     def test_it(args_in, expect_exit_code, expect_called, expect_call_args=None):
         with mock.patch.object(upload_item_data_module,
                                "upload_item_data") as mock_upload_item_data:
             try:
+                assert KeyManager.keydicts_filename() == keyfile or KeyManager.DEFAULT_KEYDICTS_FILENAME
                 upload_item_data_main(args_in)
                 mock_upload_item_data.assert_called_with(**expect_call_args)
             except SystemExit as e:

--- a/submit_cgap/tests/test_upload_item_data.py
+++ b/submit_cgap/tests/test_upload_item_data.py
@@ -1,5 +1,6 @@
 import pytest
 
+from dcicutils.misc_utils import ignored
 from dcicutils.qa_utils import override_environ
 from unittest import mock
 from ..base import KeyManager
@@ -20,11 +21,14 @@ def test_upload_item_data_script(keyfile):
                     # but inside the call, because of a decorator, the default might be different.
                     # See additional test below.
                     assert KeyManager.keydicts_filename() == KeyManager.DEFAULT_KEYDICTS_FILENAME
+
                     def mocked_upload_item_data(*args, **kwargs):
+                        ignored(args, kwargs)
                         # We don't need to test this function's actions because we test its call args below.
                         # However, we do need to run this one test from the same dynamic context,
                         # so this is close enough.
                         assert KeyManager.keydicts_filename() == (keyfile or KeyManager.DEFAULT_KEYDICTS_FILENAME)
+
                     mock_upload_item_data.side_effect = mocked_upload_item_data
                     upload_item_data_main(args_in)
                     mock_upload_item_data.assert_called_with(**expect_call_args)

--- a/submit_cgap/tests/test_upload_item_data.py
+++ b/submit_cgap/tests/test_upload_item_data.py
@@ -11,15 +11,26 @@ from ..scripts import upload_item_data as upload_item_data_module
 def test_upload_item_data_script(keyfile):
 
     def test_it(args_in, expect_exit_code, expect_called, expect_call_args=None):
-        with mock.patch.object(upload_item_data_module,
-                               "upload_item_data") as mock_upload_item_data:
-            try:
-                assert KeyManager.keydicts_filename() == keyfile or KeyManager.DEFAULT_KEYDICTS_FILENAME
-                upload_item_data_main(args_in)
-                mock_upload_item_data.assert_called_with(**expect_call_args)
-            except SystemExit as e:
-                assert e.code == expect_exit_code
-            assert mock_upload_item_data.call_count == (1 if expect_called else 0)
+
+        with override_environ(CGAP_KEYS_FILE=keyfile):
+            with mock.patch.object(upload_item_data_module,
+                                   "upload_item_data") as mock_upload_item_data:
+                try:
+                    # Outside of the call, we will always see the default filename for cgap keys
+                    # but inside the call, because of a decorator, the default might be different.
+                    # See additional test below.
+                    assert KeyManager.keydicts_filename() == KeyManager.DEFAULT_KEYDICTS_FILENAME
+                    def mocked_upload_item_data(*args, **kwargs):
+                        # We need to test this function because we test its call args below.
+                        # However, we do need to run this one test from the same dynamic context,
+                        # so this is close enough.
+                        assert KeyManager.keydicts_filename() == (keyfile or KeyManager.DEFAULT_KEYDICTS_FILENAME)
+                    mock_upload_item_data.side_effect = mocked_upload_item_data
+                    upload_item_data_main(args_in)
+                    mock_upload_item_data.assert_called_with(**expect_call_args)
+                except SystemExit as e:
+                    assert e.code == expect_exit_code
+                assert mock_upload_item_data.call_count == (1 if expect_called else 0)
 
     test_it(args_in=[], expect_exit_code=2, expect_called=False)  # Missing args
     test_it(args_in=['some.file'], expect_exit_code=0, expect_called=True, expect_call_args={


### PR DESCRIPTION
Fix environment variable `CGAP_KEYS_FILE` to allow override of what file contains the user's keys.  This is intended only for internal use, not for end users, which is why it's not an argument to the relevant commands.