### PR TITLE
Fix scripts/publish (C4-512)

### DIFF
--- a/.github/workflows/main-publish.yml
+++ b/.github/workflows/main-publish.yml
@@ -24,6 +24,9 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
       - name: Publish
         env:
           PYPI_USER: ${{ secrets.PYPI_USER }}

--- a/.github/workflows/main-publish.yml
+++ b/.github/workflows/main-publish.yml
@@ -28,5 +28,5 @@ jobs:
         env:
           PYPI_USER: ${{ secrets.PYPI_USER }}
           PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: make publish
+        run: make publish-for-ga
 

--- a/.github/workflows/main-publish.yml
+++ b/.github/workflows/main-publish.yml
@@ -28,5 +28,6 @@ jobs:
         env:
           PYPI_USER: ${{ secrets.PYPI_USER }}
           PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: make publish-for-ga
-
+        run: | 
+          make configure
+          make publish-for-ga

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,15 @@ Change Log
 ----------
 
 
+0.7.1
+=====
+
+**PR 10: Fix scripts/publish**
+
+* Fix the ``scripts/publish`` script to work on GitHub Actions (GA)
+  by allowing a ``--noconfirm`` argument.
+
+
 0.7.0
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Change Log
 ----------
 
 
-0.7.2
+0.7.3
 =====
 
 **PR 10: Fix scripts/publish (C4-512)**
@@ -16,11 +16,10 @@ Change Log
   by allowing a ``--noconfirm`` argument.
 
 
-0.7.1
-=====
+0.7.1, 0.7.2
+============
 
-This PR had problems and was reissued as version 0.7.2.
-
+These versions had flaws. The intended changes were released as version 0.7.3.
 
 0.7.0
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Change Log
 0.7.1
 =====
 
-**PR 10: Fix scripts/publish**
+**PR 10: Fix scripts/publish (C4-512)**
 
 * Fix the ``scripts/publish`` script to work on GitHub Actions (GA)
   by allowing a ``--noconfirm`` argument.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,13 +7,19 @@ Change Log
 ----------
 
 
-0.7.1
+0.7.2
 =====
 
 **PR 10: Fix scripts/publish (C4-512)**
 
 * Fix the ``scripts/publish`` script to work on GitHub Actions (GA)
   by allowing a ``--noconfirm`` argument.
+
+
+0.7.1
+=====
+
+This PR had problems and was reissued as version 0.7.2.
 
 
 0.7.0

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ update:  # updates dependencies
 publish:
 	scripts/publish
 
+publish-for-ga:
+	scripts/publish --noconfirm
+
 help:
 	@make info
 
@@ -33,5 +36,5 @@ info:
 	   $(info - Use 'make build' to install dependencies using poetry.)
 	   $(info - Use 'make publish' to publish this library, but only if auto-publishing has failed.)
 	   $(info - Use 'make retest' to run failing tests from the previous test run.)
-	   $(info - Use 'make test' to run tests with the normal options we use on travis)
+	   $(info - Use 'make test' to run tests with the normal options we use for CI/CD like GA.)
 	   $(info - Use 'make update' to update dependencies (and the lock file))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "submit_cgap"
-version = "0.7.0"
+version = "0.7.1"
 description = "Support for uploading file submissions to the Clinical Genomics Analysis Platform (CGAP)."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "submit_cgap"
-version = "0.7.2"
+version = "0.7.3"
 description = "Support for uploading file submissions to the Clinical Genomics Analysis Platform (CGAP)."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "submit_cgap"
-version = "0.7.1"
+version = "0.7.2"
 description = "Support for uploading file submissions to the Clinical Genomics Analysis Platform (CGAP)."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/scripts/publish
+++ b/scripts/publish
@@ -12,7 +12,7 @@ while true; do
        echo "In a script, you may want --noconfirm to suppress this query."
        exit 1
     elif [ "$1" = "--noconfirm" ]; then
-       do_confirm=yes
+       do_confirm=no
        shift 1
     elif [ $# -ne 0 ]; then
        echo "Unexpected argument: $1"

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,5 +1,27 @@
 #!/bin/bash
 
+do_confirm=yes
+
+while true; do
+    if [ "$1" = "--help" ]; then
+       echo "Syntax: $0 [ --noconfirm | --help ]*"
+       echo ""
+       echo "Publishes the repository to pypi, after doing various consistency checks."
+       echo ""
+       echo "By default, if all looks good, you will be asked interactively for confirmation."
+       echo "In a script, you may want --noconfirm to suppress this query."
+       exit 1
+    elif [ "$1" = "--noconfirm" ]; then
+       do_confirm=yes
+       shift 1
+    elif [ $# -ne 0 ]; then
+       echo "Unexpected argument: $1"
+       exit 1
+    else
+       break
+    fi
+done
+
 if [ -z "$PYPI_USER" ]; then
     echo '$PYPI_USER is not set.'
     exit 1
@@ -32,12 +54,14 @@ if [ -z "$tagged" ]; then
   exit 1
 fi
 
-read -p "Are you sure you want to publish $(poetry version) to PyPi? "
-REPLY=`echo "$REPLY" | tr '[:upper:]' '[:lower:]'`
-if [ "$REPLY" != 'y' ] && [ "$REPLY" != "yes" ]
-then
-  echo "Publishing aborted."
-  exit 1
+if [ "${do_confirm}" = "yes" ]; then
+  read -p "Are you sure you want to publish $(poetry version) to PyPi? "
+  REPLY=`echo "$REPLY" | tr '[:upper:]' '[:lower:]'`
+  if [ "$REPLY" != 'y' ] && [ "$REPLY" != "yes" ]
+  then
+    echo "Publishing aborted."
+    exit 1
+  fi
 fi
 
 poetry publish --no-interaction --build --username=$PYPI_USER --password=$PYPI_PASSWORD


### PR DESCRIPTION
Make `scripts/publish` take a `--noconfirm` argument.
(Adusts github actions to use the argument.)