### PR TITLE
Gene List Submission

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Change Log
 0.8.0
 =====
 
-**PR 11: SubmitCGAP submit-genelist**
+**PR 12: SubmitCGAP submit-genelist**
 
 * Add ``submit-genelist`` command for uploading gene lists
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ SubmitCGAP
 Change Log
 ----------
 
+0.8.0
+=====
+
+**PR 11: SubmitCGAP submit-genelist**
+
+* Add ``submit-genelist`` command for uploading gene lists
 
 0.7.3
 =====

--- a/README.rst
+++ b/README.rst
@@ -23,16 +23,18 @@ Description
 
 This is a tool for uploading certain kinds of files to CGAP.
 
-Initial support is for "metadata bundles", which are Excel files
-(such as .xls or .xlsx files)
-that are accompanied by other files (such as ``.fastq.gz`` files).
+Current support is for "metadata bundles" and "gene lists".
+"Metadata bundles" are Excel files (.xlsx) accompanied by other files 
+(such as ``.fastq.gz`` files). 
+"Gene lists" are either Excel files (.xlsx) or plain text (.txt) files.
 
 
 About Metadata Bundles
 ======================
+"Metadata bundles" are Excel files (.xlsx) accompanied by other files 
+(such as ``.fastq.gz`` files). 
 
-.. note::
-
+**Note**:
    The format of the Excel files that are used as
    "metadata bundles" is not yet documented.
    For now you should begin by obtaining a template file from
@@ -71,8 +73,13 @@ Getting Started
 ===============
 
 Once ``poetry`` has finished installing this library into your virtual environment,
-you should have access to the ``submit-metadata-bundle`` command.
-For help about its arguments, do::
+you should have access to the ``submit-metadata-bundle`` and the ``submit-genelist``
+commands.
+
+Metadata Bundles
+----------------
+
+For help about arguments, do::
 
    submit-metadata-bundle --help
 
@@ -107,3 +114,19 @@ or::
    upload-item-data <filename> --uuid <item-uuid> --server <server>
 
 where the ``<item-uuid>`` is the uuid for the individual item, not the metadata bundle.
+
+Gene Lists
+----------
+
+The ``submit-genelist`` command shares similar features with ``submit-metadata-bundle``.
+For help about arguments, do::
+
+   submit-genelist --help
+
+and to submit a gene list for validation only, do::
+
+   submit-genelist --validate-only
+
+For most situations, simply specify the gene list you want to upload, e.g.::
+
+   submit-genelist mygenelist.xlsx

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ SubmitCGAP
 
 
 A file submission tool for CGAP
--------------------------------
+===============================
 
 .. image:: https://travis-ci.org/dbmi-bgm/SubmitCGAP.svg
    :target: https://travis-ci.org/dbmi-bgm/SubmitCGAP
@@ -34,7 +34,8 @@ About Metadata Bundles
 "Metadata bundles" are Excel files (.xlsx) accompanied by other files 
 (such as ``.fastq.gz`` files). 
 
-Note: The format of the Excel files that are used as
+**Note**
+The format of the Excel files that are used as
 "metadata bundles" is not yet documented.
 For now you should begin by obtaining a template file from
 your contact on the CGAP Team and then customize that as appropriate.
@@ -76,7 +77,7 @@ you should have access to the ``submit-metadata-bundle`` and the ``submit-geneli
 commands.
 
 Metadata Bundles
-^^^^^^^^^^^^^^^^
+----------------
 
 For help about arguments, do::
 
@@ -115,7 +116,7 @@ or::
 where the ``<item-uuid>`` is the uuid for the individual item, not the metadata bundle.
 
 Gene Lists
-^^^^^^^^^^
+----------
 
 The ``submit-genelist`` command shares similar features with ``submit-metadata-bundle``.
 For help about arguments, do::

--- a/README.rst
+++ b/README.rst
@@ -34,11 +34,10 @@ About Metadata Bundles
 "Metadata bundles" are Excel files (.xlsx) accompanied by other files 
 (such as ``.fastq.gz`` files). 
 
-**Note**:
-   The format of the Excel files that are used as
-   "metadata bundles" is not yet documented.
-   For now you should begin by obtaining a template file from
-   your contact on the CGAP Team and then customize that as appropriate.
+Note: The format of the Excel files that are used as
+"metadata bundles" is not yet documented.
+For now you should begin by obtaining a template file from
+your contact on the CGAP Team and then customize that as appropriate.
 
 Installation
 ============
@@ -77,7 +76,7 @@ you should have access to the ``submit-metadata-bundle`` and the ``submit-geneli
 commands.
 
 Metadata Bundles
-----------------
+^^^^^^^^^^^^^^^^
 
 For help about arguments, do::
 
@@ -116,7 +115,7 @@ or::
 where the ``<item-uuid>`` is the uuid for the individual item, not the metadata bundle.
 
 Gene Lists
-----------
+^^^^^^^^^^
 
 The ``submit-genelist`` command shares similar features with ``submit-metadata-bundle``.
 For help about arguments, do::

--- a/README.rst
+++ b/README.rst
@@ -24,17 +24,17 @@ Description
 This is a tool for uploading certain kinds of files to CGAP.
 
 Current support is for "metadata bundles" and "gene lists".
-"Metadata bundles" are Excel files (.xlsx) accompanied by other files 
+"Metadata bundles" are Excel files (``.xlsx``) accompanied by other files 
 (such as ``.fastq.gz`` files). 
-"Gene lists" are either Excel files (.xlsx) or plain text (.txt) files.
+"Gene lists" are either Excel files (``.xlsx``) or plain text (``.txt``) files.
 
 
 About Metadata Bundles
 ======================
-"Metadata bundles" are Excel files (.xlsx) accompanied by other files 
+"Metadata bundles" are Excel files (``.xlsx``) accompanied by other files 
 (such as ``.fastq.gz`` files). 
 
-**Note**
+**Note:**
 The format of the Excel files that are used as
 "metadata bundles" is not yet documented.
 For now you should begin by obtaining a template file from

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ resume-uploads = "submit_cgap.scripts.resume_uploads:main"
 show-upload-info = "submit_cgap.scripts.show_upload_info:main"
 submit-metadata-bundle = "submit_cgap.scripts.submit_metadata_bundle:main"
 upload-item-data = "submit_cgap.scripts.upload_item_data:main"
+submit-genelist = "submit_cgap.scripts.submit_genelist:main"
 
 [tool.coverage.report]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "submit_cgap"
-version = "0.7.3"
+version = "0.8.0"
 description = "Support for uploading file submissions to the Clinical Genomics Analysis Platform (CGAP)."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/submit_cgap/scripts/submit_genelist.py
+++ b/submit_cgap/scripts/submit_genelist.py
@@ -43,15 +43,10 @@ def main(simulated_args_for_testing=None):
             help="whether to stop after validating without submitting",
             default=False
     )
-    parser.add_argument(
-            '--ingestion_type', '-t', help="the ingestion type",
-            default='genelist'
-    )
     args = parser.parse_args(args=simulated_args_for_testing)
 
     return submit_any_ingestion(
             ingestion_filename=args.genelist_filename,
-            ingestion_type=args.ingestion_type,
             institution=args.institution,
             project=args.project,
             server=args.server,

--- a/submit_cgap/scripts/submit_genelist.py
+++ b/submit_cgap/scripts/submit_genelist.py
@@ -57,7 +57,6 @@ def main(simulated_args_for_testing=None):
             server=args.server,
             env=args.env,
             validate_only=args.validate_only,
-            upload_folder=args.upload_folder,
     )
 
 

--- a/submit_cgap/scripts/submit_genelist.py
+++ b/submit_cgap/scripts/submit_genelist.py
@@ -47,6 +47,7 @@ def main(simulated_args_for_testing=None):
 
     return submit_any_ingestion(
             ingestion_filename=args.genelist_filename,
+            ingestion_type='genelist',
             institution=args.institution,
             project=args.project,
             server=args.server,

--- a/submit_cgap/scripts/submit_genelist.py
+++ b/submit_cgap/scripts/submit_genelist.py
@@ -1,0 +1,65 @@
+import argparse
+from ..submission import submit_any_ingestion
+from ..base import UsingCGAPKeysFile
+
+
+EPILOG = __doc__
+
+
+@UsingCGAPKeysFile
+def main(simulated_args_for_testing=None):
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
+        description="Submits a gene list",
+        epilog=EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+            'genelist_filename',
+            help='a local Excel or txt filename that is the gene list'
+    )
+    parser.add_argument(
+            '--institution', '-i',
+            help='institution identifier',
+            default=None
+    )
+    parser.add_argument(
+            '--project', '-p',
+            help='project identifier',
+            default=None
+    )
+    parser.add_argument(
+            '--server', '-s',
+            help="an http or https address of the server to use",
+            default=None
+    )
+    parser.add_argument(
+            '--env', '-e',
+            help="a CGAP beanstalk environment name for the server to use",
+            default=None
+    )
+    parser.add_argument(
+            '--validate-only', '-v',
+            action="store_true",
+            help="whether to stop after validating without submitting",
+            default=False
+    )
+    parser.add_argument(
+            '--ingestion_type', '-t', help="the ingestion type",
+            default='genelist'
+    )
+    args = parser.parse_args(args=simulated_args_for_testing)
+
+    return submit_any_ingestion(
+            ingestion_filename=args.genelist_filename,
+            ingestion_type=args.ingestion_type,
+            institution=args.institution,
+            project=args.project,
+            server=args.server,
+            env=args.env,
+            validate_only=args.validate_only,
+            upload_folder=args.upload_folder,
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/submit_cgap/tests/test_submit_genelist.py
+++ b/submit_cgap/tests/test_submit_genelist.py
@@ -27,7 +27,7 @@ def test_submit_metadata_bundle_script(keyfile):
 
                     def mocked_submit_genelist(*args, **kwargs):
                         ignored(args, kwargs)
-                        # We don't need to test this function's actionsusin because we test its call args below.
+                        # We don't need to test this function's actions because we test its call args below.
                         # However, we do need to run this one test from the same dynamic context,
                         # so this is close enough.
                         assert KeyManager.keydicts_filename() == (keyfile or KeyManager.DEFAULT_KEYDICTS_FILENAME)

--- a/submit_cgap/tests/test_submit_genelist.py
+++ b/submit_cgap/tests/test_submit_genelist.py
@@ -10,6 +10,7 @@ from ..scripts import submit_genelist as submit_genelist_module
 
 INGESTION_TYPE = "genelist"
 
+
 @pytest.mark.parametrize("keyfile", [None, "foo.bar"])
 def test_submit_metadata_bundle_script(keyfile):
 

--- a/submit_cgap/tests/test_submit_genelist.py
+++ b/submit_cgap/tests/test_submit_genelist.py
@@ -1,0 +1,69 @@
+import pytest
+
+from dcicutils.misc_utils import ignored
+from dcicutils.qa_utils import override_environ
+from unittest import mock
+from ..base import KeyManager
+from ..scripts.submit_genelist import main as submit_genelist_main
+from ..scripts import submit_genelist as submit_genelist_module
+
+INGESTION_TYPE = "genelist"
+
+@pytest.mark.parametrize("keyfile", [None, "foo.bar"])
+def test_submit_metadata_bundle_script(keyfile):
+
+    def test_it(args_in, expect_exit_code, expect_called, expect_call_args=None):
+
+        with override_environ(CGAP_KEYS_FILE=keyfile):
+            with mock.patch.object(submit_genelist_module,
+                                   "submit_any_ingestion") as mock_submit_any_ingestion:
+                try:
+                    # Outside of the call, we will always see the default filename for cgap keys
+                    # but inside the call, because of a decorator, the default might be different.
+                    # See additional test below.
+                    assert KeyManager.keydicts_filename() == KeyManager.DEFAULT_KEYDICTS_FILENAME
+
+                    def mocked_submit_genelist(*args, **kwargs):
+                        ignored(args, kwargs)
+                        # We don't need to test this function's actionsusin because we test its call args below.
+                        # However, we do need to run this one test from the same dynamic context,
+                        # so this is close enough.
+                        assert KeyManager.keydicts_filename() == (keyfile or KeyManager.DEFAULT_KEYDICTS_FILENAME)
+
+                    mock_submit_any_ingestion.side_effect = mocked_submit_genelist
+                    submit_genelist_main(args_in)
+                    mock_submit_any_ingestion.assert_called_with(**expect_call_args)
+                except SystemExit as e:
+                    assert e.code == expect_exit_code
+                assert mock_submit_any_ingestion.call_count == (1 if expect_called else 0)
+
+    test_it(args_in=[], expect_exit_code=2, expect_called=False)  # Missing args
+    test_it(args_in=['some-file'], expect_exit_code=0, expect_called=True, expect_call_args={
+        'ingestion_filename': 'some-file',
+        'ingestion_type': INGESTION_TYPE,
+        'env': None,
+        'server': None,
+        'institution': None,
+        'project': None,
+        'validate_only': False,
+    })
+    expect_call_args = {
+        'ingestion_filename': 'some-file',
+        'ingestion_type': INGESTION_TYPE,
+        'env': "some-env",
+        'server': "some-server",
+        'institution': "some-institution",
+        'project': "some-project",
+        'validate_only': True,
+    }
+    test_it(args_in=["--env", "some-env", "--institution", "some-institution",
+                     "-s", "some-server", "-v", "-p", "some-project",
+                     "some-file"],
+            expect_exit_code=0,
+            expect_called=True,
+            expect_call_args=expect_call_args)
+    test_it(args_in=["some-file", "--env", "some-env", "--institution", "some-institution",
+                     "-s", "some-server", "--validate-only", "-p", "some-project"],
+            expect_exit_code=0,
+            expect_called=True,
+            expect_call_args=expect_call_args)

--- a/submit_cgap/tests/test_submit_genelist.py
+++ b/submit_cgap/tests/test_submit_genelist.py
@@ -7,6 +7,7 @@ from ..base import KeyManager
 from ..scripts.submit_genelist import main as submit_genelist_main
 from ..scripts import submit_genelist as submit_genelist_module
 
+
 INGESTION_TYPE = "genelist"
 
 @pytest.mark.parametrize("keyfile", [None, "foo.bar"])

--- a/submit_cgap/tests/test_submit_metadata_bundle.py
+++ b/submit_cgap/tests/test_submit_metadata_bundle.py
@@ -25,7 +25,7 @@ def test_submit_metadata_bundle_script(keyfile):
 
                     def mocked_submit_metadata_bundle(*args, **kwargs):
                         ignored(args, kwargs)
-                        # We don't need to test this function's actionsusin because we test its call args below.
+                        # We don't need to test this function's actions because we test its call args below.
                         # However, we do need to run this one test from the same dynamic context,
                         # so this is close enough.
                         assert KeyManager.keydicts_filename() == (keyfile or KeyManager.DEFAULT_KEYDICTS_FILENAME)


### PR DESCRIPTION
Enable users to submit gene lists via SubmitCGAP tools. 

Main additions are:

- submit-genelist command
- updated documentation
- accompanying tests

and all more or less mimicked the existing versions for submit-metadata-bundle. 