### PR TITLE
Support s3_encrypt_key_id in upload_credentials (C4-746), fix coveralls (C4-523)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,3 +45,10 @@ jobs:
       - name: CI
         run: |
           poetry run coverage run --source submit_cgap -m pytest -vv
+
+      - name: Coveralls
+        # env:
+        #   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ matrix.python_version == '3.6' }}
+        run: |
+          poetry run coveralls --service=github

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,8 +47,8 @@ jobs:
           poetry run coverage run --source submit_cgap -m pytest -vv
 
       - name: Coveralls
-        # env:
-        #   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ matrix.python_version == '3.6' }}
         run: |
           poetry run coveralls --service=github

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,11 +7,19 @@ Change Log
 ----------
 
 
-1.1.0
+1.2.0
 =====
 
-Support for proper handling of s3_encrypt_key_id where one is available
-(e.g., as shown in health page).
+* Implements an optimization of the submission protocol so that if
+  the ``upload_credentials`` contain an entry for ``s3_encrypt_key_id``,
+  that value is used without the health page having to be consulted.
+
+
+1.1.1
+=====
+
+* Support for proper handling of ``s3_encrypt_key_id`` where one is available
+  (e.g., as shown in health page).
 
 
 1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "submit_cgap"
-version = "1.1.0"
+version = "1.1.1"
 description = "Support for uploading file submissions to the Clinical Genomics Analysis Platform (CGAP)."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/submit_cgap/tests/test_submission.py
+++ b/submit_cgap/tests/test_submission.py
@@ -688,7 +688,8 @@ def test_get_s3_encrypt_key_id(debug_protocol):
                 assert (get_s3_encrypt_key_id(upload_credentials=upload_creds, auth='not-used-by-mock')
                         == 'gotten-from-upload-creds')
                 assert mock_health_page_getter.call_count == 0
-                assert printed.lines == (['Extracted s3_encrypt_key_id from upload_credentials: gotten-from-upload-creds']
+                assert printed.lines == (['Extracted s3_encrypt_key_id from upload_credentials:'
+                                          ' gotten-from-upload-creds']
                                          if debug_protocol
                                          else [])
 


### PR DESCRIPTION
* Support for finding an `s3_encrypt_key_id` entry in `upload_credentials`, to avoid having to get the health page.

Opportunistic:

* Repairs coveralls.
