### PR TITLE
More comprehensive use of script_catch_errors to avoid tracebacks (C4-790)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ Change Log
 ----------
 
 
+1.4.0
+=====
+
+* Suppress stack traceback on unexpected errors.
+* Allow suppression behavior to be overridden by setting environment variable ``DEBUG_CGAP=TRUE``.
+* Add an instructive herald before unexpected errors, suggesting that a bug report might need to be filed.
+
+
 1.3.0
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "submit_cgap"
-version = "1.3.0"
+version = "1.4.0"
 description = "Support for uploading file submissions to the Clinical Genomics Analysis Platform (CGAP)."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/submit_cgap/scripts/make_sample_fastq_file.py
+++ b/submit_cgap/scripts/make_sample_fastq_file.py
@@ -1,6 +1,7 @@
 import argparse
 
 from dcicutils.data_utils import generate_sample_fastq_file
+from ..utils import script_catch_errors
 
 
 EPILOG = __doc__
@@ -16,7 +17,9 @@ def main(simulated_args_for_testing=None):
     parser.add_argument('--number', '-n', help='number of sequences', default=10, type=int)
     parser.add_argument('--length', '-l', help='length of sequences', default=10, type=int)
     args = parser.parse_args(args=simulated_args_for_testing)
-    generate_sample_fastq_file(filename=args.filename, num=args.number, length=args.length)
+
+    with script_catch_errors():
+        generate_sample_fastq_file(filename=args.filename, num=args.number, length=args.length)
 
 
 if __name__ == '__main__':

--- a/submit_cgap/scripts/resume_uploads.py
+++ b/submit_cgap/scripts/resume_uploads.py
@@ -1,6 +1,7 @@
 import argparse
 from ..submission import resume_uploads
 from ..base import UsingCGAPKeysFile
+from ..utils import script_catch_errors
 
 
 EPILOG = __doc__
@@ -24,8 +25,10 @@ def main(simulated_args_for_testing=None):
                         help="search subfolders of folder for upload files", default=False)
     args = parser.parse_args(args=simulated_args_for_testing)
 
-    resume_uploads(uuid=args.uuid, server=args.server, env=args.env, bundle_filename=args.bundle_filename,
-                   upload_folder=args.upload_folder, no_query=args.no_query, subfolders=args.subfolders)
+    with script_catch_errors():
+
+        resume_uploads(uuid=args.uuid, server=args.server, env=args.env, bundle_filename=args.bundle_filename,
+                       upload_folder=args.upload_folder, no_query=args.no_query, subfolders=args.subfolders)
 
 
 if __name__ == '__main__':

--- a/submit_cgap/scripts/show_upload_info.py
+++ b/submit_cgap/scripts/show_upload_info.py
@@ -1,6 +1,7 @@
 import argparse
 from ..submission import show_upload_info
 from ..base import UsingCGAPKeysFile
+from ..utils import script_catch_errors
 
 
 EPILOG = __doc__
@@ -18,7 +19,9 @@ def main(simulated_args_for_testing=None):
     parser.add_argument('--env', '-e', help="a CGAP beanstalk environment name for the server to use", default=None)
     args = parser.parse_args(args=simulated_args_for_testing)
 
-    show_upload_info(uuid=args.uuid, server=args.server, env=args.env)
+    with script_catch_errors():
+
+        show_upload_info(uuid=args.uuid, server=args.server, env=args.env)
 
 
 if __name__ == '__main__':

--- a/submit_cgap/scripts/submit_metadata_bundle.py
+++ b/submit_cgap/scripts/submit_metadata_bundle.py
@@ -1,6 +1,7 @@
 import argparse
 from ..submission import submit_any_ingestion, DEFAULT_INGESTION_TYPE
 from ..base import UsingCGAPKeysFile
+from ..utils import script_catch_errors
 
 
 EPILOG = __doc__
@@ -28,12 +29,14 @@ def main(simulated_args_for_testing=None):
                         help="search subfolders of folder for upload files", default=False)
     args = parser.parse_args(args=simulated_args_for_testing)
 
-    return submit_any_ingestion(ingestion_filename=args.bundle_filename, ingestion_type=args.ingestion_type,
-                                institution=args.institution, project=args.project,
-                                server=args.server, env=args.env,
-                                validate_only=args.validate_only, upload_folder=args.upload_folder,
-                                no_query=args.no_query, subfolders=args.subfolders
-                                )
+    with script_catch_errors():
+
+        submit_any_ingestion(ingestion_filename=args.bundle_filename, ingestion_type=args.ingestion_type,
+                             institution=args.institution, project=args.project,
+                             server=args.server, env=args.env,
+                             validate_only=args.validate_only, upload_folder=args.upload_folder,
+                             no_query=args.no_query, subfolders=args.subfolders,
+                             )
 
 
 if __name__ == '__main__':

--- a/submit_cgap/scripts/upload_item_data.py
+++ b/submit_cgap/scripts/upload_item_data.py
@@ -1,6 +1,7 @@
 import argparse
 from ..submission import upload_item_data
 from ..base import UsingCGAPKeysFile
+from ..utils import script_catch_errors
 
 
 EPILOG = __doc__
@@ -21,8 +22,10 @@ def main(simulated_args_for_testing=None):
                         help="suppress requests for user input", default=False)
     args = parser.parse_args(args=simulated_args_for_testing)
 
-    upload_item_data(item_filename=args.part_filename, uuid=args.uuid, server=args.server,
-                     env=args.env, no_query=args.no_query)
+    with script_catch_errors():
+
+        upload_item_data(item_filename=args.part_filename, uuid=args.uuid, server=args.server,
+                         env=args.env, no_query=args.no_query)
 
 
 if __name__ == '__main__':

--- a/submit_cgap/submission.py
+++ b/submit_cgap/submission.py
@@ -503,7 +503,11 @@ def get_s3_encrypt_key_id_from_health_page(auth):
     try:
         health = get_health_page(key=auth)
         return health.get(HealthPageKey.S3_ENCRYPT_KEY_ID)
-    except Exception:
+    except Exception:  # pragma: no cover
+        # We don't actually unit test this section because get_health_page realistically always returns
+        # a dictionary, and so health.get(...) always succeeds, possibly returning None, which should
+        # already be tested. Returning None here amounts to the same and needs no extra unit testing.
+        # The presence of this error clause is largely pro forma and probably not really needed.
         return None
 
 

--- a/submit_cgap/submission.py
+++ b/submit_cgap/submission.py
@@ -207,16 +207,6 @@ def ingestion_submission_item_url(server, uuid):
     return url_path_join(server, "ingestion-submissions", uuid) + "?format=json"
 
 
-@contextlib.contextmanager
-def script_catch_errors():
-    try:
-        yield
-        exit(0)
-    except Exception as e:
-        show("%s: %s" % (e.__class__.__name__, str(e)))
-        exit(1)
-
-
 DEBUG_PROTOCOL = environ_bool("DEBUG_PROTOCOL", default=False)
 
 
@@ -316,7 +306,7 @@ def submit_any_ingestion(ingestion_filename, ingestion_type, institution, projec
     :param subfolders: bool to search subdirectories within upload_folder for files
     """
 
-    with script_catch_errors():
+    if True:
 
         server = resolve_server(server=server, env=env)
 
@@ -454,7 +444,8 @@ def show_upload_info(uuid, server=None, env=None, keydict=None):
     :param keydict: keydict-style auth, a dictionary of 'key', 'secret', and 'server'
     """
 
-    with script_catch_errors():
+    # with script_catch_errors():
+    if True:
 
         server = resolve_server(server=server, env=env)
         keydict = keydict or get_keydict_for_server(server)
@@ -500,7 +491,8 @@ def resume_uploads(uuid, server=None, env=None, bundle_filename=None, keydict=No
     :param subfolders: bool to search subdirectories within upload_folder for files
     """
 
-    with script_catch_errors():
+    # with script_catch_errors():
+    if True:
 
         server = resolve_server(server=server, env=env)
         keydict = keydict or get_keydict_for_server(server)

--- a/submit_cgap/submission.py
+++ b/submit_cgap/submission.py
@@ -236,7 +236,7 @@ def _post_submission(server, keypair, ingestion_filename, creation_post_data, su
                              headers={'Content-type': 'application/json'},
                              files=post_files_data())
 
-    if DEBUG_PROTOCOL:
+    if DEBUG_PROTOCOL:  # pragma: no cover
         PRINT("old_style_submission_url=", old_style_submission_url)
         PRINT("old_style_post_data=", json.dumps(old_style_post_data, indent=2))
         PRINT("keypair=", keypair)
@@ -244,7 +244,7 @@ def _post_submission(server, keypair, ingestion_filename, creation_post_data, su
 
     if response.status_code == 404:
 
-        if DEBUG_PROTOCOL:
+        if DEBUG_PROTOCOL:  # pragma: no cover
             PRINT("Retrying with new protocol.")
 
         creation_post_headers = {
@@ -252,7 +252,7 @@ def _post_submission(server, keypair, ingestion_filename, creation_post_data, su
             'Accept': 'application/json',
         }
         creation_post_url = url_path_join(server, "IngestionSubmission")
-        if DEBUG_PROTOCOL:
+        if DEBUG_PROTOCOL:  # pragma: no cover
             PRINT("creation_post_data=", json.dumps(creation_post_data, indent=2))
             PRINT("creation_post_url=", creation_post_url)
         creation_response = requests.post(creation_post_url, auth=keypair,
@@ -260,26 +260,26 @@ def _post_submission(server, keypair, ingestion_filename, creation_post_data, su
                                           json=creation_post_data
                                           # data=json.dumps(creation_post_data)
                                           )
-        if DEBUG_PROTOCOL:
+        if DEBUG_PROTOCOL:  # pragma: no cover
             PRINT("headers:", creation_response.request.headers)
         creation_response.raise_for_status()
         [submission] = creation_response.json()['@graph']
         submission_id = submission['@id']
 
-        if DEBUG_PROTOCOL:
+        if DEBUG_PROTOCOL:  # pragma: no cover
             PRINT("server=", server, "submission_id=", submission_id)
         new_style_submission_url = url_path_join(server, submission_id, "submit_for_ingestion")
-        if DEBUG_PROTOCOL:
+        if DEBUG_PROTOCOL:  # pragma: no cover
             PRINT("submitting new_style_submission_url=", new_style_submission_url)
         response = requests.post(new_style_submission_url, auth=keypair, data=submission_post_data,
                                  files=post_files_data())
-        if DEBUG_PROTOCOL:
+        if DEBUG_PROTOCOL:  # pragma: no cover
             PRINT("response received for submission post:", response)
             PRINT("response.content:", response.content)
 
     else:
 
-        if DEBUG_PROTOCOL:
+        if DEBUG_PROTOCOL:  # pragma: no cover
             PRINT("Old style protocol worked.")
 
     return response
@@ -510,14 +510,14 @@ def get_s3_encrypt_key_id_from_health_page(auth):
 def get_s3_encrypt_key_id(*, upload_credentials, auth):
     if 's3_encrypt_key_id' in upload_credentials:
         s3_encrypt_key_id = upload_credentials.get('s3_encrypt_key_id')
-        if DEBUG_PROTOCOL:
+        if DEBUG_PROTOCOL:  # pragma: no cover
             PRINT(f"Extracted s3_encrypt_key_id from upload_credentials: {s3_encrypt_key_id}")
     else:
-        if DEBUG_PROTOCOL:
+        if DEBUG_PROTOCOL:  # pragma: no cover
             PRINT(f"No s3_encrypt_key_id entry found in upload_credentials.")
             PRINT(f"Fetching s3_encrypt_key_id from health page.")
         s3_encrypt_key_id = get_s3_encrypt_key_id_from_health_page(auth)
-        if DEBUG_PROTOCOL:
+        if DEBUG_PROTOCOL:  # pragma: no cover
             PRINT(f" =id=> {s3_encrypt_key_id!r}")
     return s3_encrypt_key_id
 
@@ -533,7 +533,7 @@ def execute_prearranged_upload(path, upload_credentials, auth=None):
         and possibly other useful information such as an encryption key id.
     """
 
-    if DEBUG_PROTOCOL:
+    if DEBUG_PROTOCOL:  # pragma: no cover
         PRINT(f"Upload credentials contain {conjoined_list(list(upload_credentials.keys()))}.")
     try:
         s3_encrypt_key_id = get_s3_encrypt_key_id(upload_credentials=upload_credentials, auth=auth)
@@ -553,7 +553,7 @@ def execute_prearranged_upload(path, upload_credentials, auth=None):
         if s3_encrypt_key_id:
             command = command + ['--sse', 'aws:kms', '--sse-kms-key-id', s3_encrypt_key_id]
         command = command + ['--only-show-errors', source, target]
-        if DEBUG_PROTOCOL:
+        if DEBUG_PROTOCOL:  # pragma: no cover
             PRINT(f"Executing: {command}")
             PRINT(f" ==> {' '.join(command)}")
             PRINT(f"Environment variables include {conjoined_list(list(extra_env.keys()))}.")

--- a/submit_cgap/submission.py
+++ b/submit_cgap/submission.py
@@ -1,4 +1,3 @@
-import contextlib
 import glob
 import io
 import json
@@ -530,6 +529,8 @@ def execute_prearranged_upload(path, upload_credentials, auth=None):
     :param path: the name of a local file to upload
     :param upload_credentials: a dictionary of credentials to be used for the upload,
         containing the keys 'AccessKeyId', 'SecretAccessKey', 'SessionToken', and 'upload_url'.
+    :param auth: auth info in the form of a dictionary containing 'key', 'secret', and 'server',
+        and possibly other useful information such as an encryption key id.
     """
 
     if DEBUG_PROTOCOL:

--- a/submit_cgap/submission.py
+++ b/submit_cgap/submission.py
@@ -375,7 +375,9 @@ def submit_any_ingestion(ingestion_filename, ingestion_type, institution, projec
                      " does not support metadata bundle submission.")
         raise
 
-    if res is None:
+    if res is None:  # pragma: no cover
+        # This clause is not ordinarily entered. It handles a pathological case that we only hypothesize.
+        # It does not require careful unit test coverage. -kmp 23-Feb-2022
         raise Exception("Bad JSON body in %s submission result." % response.status_code)
 
     uuid = res['submission_id']

--- a/submit_cgap/submission.py
+++ b/submit_cgap/submission.py
@@ -347,7 +347,9 @@ def submit_any_ingestion(ingestion_filename, ingestion_type, institution, projec
     try:
         # This can fail if the body doesn't contain JSON
         res = response.json()
-    except Exception:
+    except Exception:  # pragma: no cover
+        # This clause is not ordinarily entered. It handles a pathological case that we only hypothesize.
+        # It does not require careful unit test coverage. -kmp 23-Feb-2022
         res = None
 
     try:

--- a/submit_cgap/tests/test_make_sample_fastq_file.py
+++ b/submit_cgap/tests/test_make_sample_fastq_file.py
@@ -1,6 +1,7 @@
 from unittest import mock
 from ..scripts.make_sample_fastq_file import main as make_sample_fastq_file_main
 from ..scripts import make_sample_fastq_file as make_sample_fastq_file_module
+from .testing_helpers import system_exit_expected
 
 
 def test_make_sample_fastq_file_script():
@@ -8,11 +9,9 @@ def test_make_sample_fastq_file_script():
     def test_it(args_in, expect_exit_code, expect_called, expect_call_args=None):
         with mock.patch.object(make_sample_fastq_file_module,
                                "generate_sample_fastq_file") as mock_generate_sample_fastq_file:
-            try:
+            with system_exit_expected(exit_code=expect_exit_code):
                 make_sample_fastq_file_main(args_in)
                 mock_generate_sample_fastq_file.assert_called_with(**expect_call_args)
-            except SystemExit as e:
-                assert e.code == expect_exit_code
             assert mock_generate_sample_fastq_file.call_count == (1 if expect_called else 0)
 
     test_it(args_in=[], expect_exit_code=2, expect_called=False)  # Missing args

--- a/submit_cgap/tests/test_make_sample_fastq_file.py
+++ b/submit_cgap/tests/test_make_sample_fastq_file.py
@@ -11,7 +11,7 @@ def test_make_sample_fastq_file_script():
                                "generate_sample_fastq_file") as mock_generate_sample_fastq_file:
             with system_exit_expected(exit_code=expect_exit_code):
                 make_sample_fastq_file_main(args_in)
-                mock_generate_sample_fastq_file.assert_called_with(**expect_call_args)
+                raise AssertionError("make_sample_fastq_file_main should not exit normally.")  # pragma: no cover
             assert mock_generate_sample_fastq_file.call_count == (1 if expect_called else 0)
 
     test_it(args_in=[], expect_exit_code=2, expect_called=False)  # Missing args

--- a/submit_cgap/tests/test_resume_uploads.py
+++ b/submit_cgap/tests/test_resume_uploads.py
@@ -34,7 +34,7 @@ def test_resume_uploads_script(keyfile):
 
                         mock_resume_uploads.side_effect = mocked_resume_uploads
                         resume_uploads_main(args_in)
-                        mock_resume_uploads.assert_called_with(**expect_call_args)
+                        raise AssertionError("resume_uploads_main should not exit normally.")  # pragma: no cover
                     except SystemExit as e:
                         assert e.code == expect_exit_code
                     assert mock_resume_uploads.call_count == (1 if expect_called else 0)

--- a/submit_cgap/tests/test_show_upload_info.py
+++ b/submit_cgap/tests/test_show_upload_info.py
@@ -32,7 +32,7 @@ def test_show_upload_info_script(keyfile):
 
                         mock_show_upload_info.side_effect = mocked_show_upload_info
                         show_upload_info_main(args_in)
-                        mock_show_upload_info.assert_called_with(**expect_call_args)
+                        raise AssertionError("show_upload_info_main should not exit normally.")  # pragma: no cover
                     except SystemExit as e:
                         assert e.code == expect_exit_code
                     assert mock_show_upload_info.call_count == (1 if expect_called else 0)

--- a/submit_cgap/tests/test_submission.py
+++ b/submit_cgap/tests/test_submission.py
@@ -22,7 +22,7 @@ from ..submission import (
     upload_file_to_uuid, upload_item_data, PROGRESS_CHECK_INTERVAL,
     get_s3_encrypt_key_id, get_s3_encrypt_key_id_from_health_page,
 )
-from ..utils import FakeResponse, script_catch_errors
+from ..utils import FakeResponse, script_catch_errors, ERROR_HERALD
 
 
 SOME_AUTH = ('my-key-id', 'good-secret')
@@ -479,7 +479,7 @@ def test_script_catch_errors():
         else:
             raise AssertionError("SystemExit not raised.")  # pragma: no cover - we hope never to see this executed
 
-        assert shown.lines == ["RuntimeError: Some error"]
+        assert shown.lines == [ERROR_HERALD, "RuntimeError: Some error"]
 
 
 def test_do_any_uploads():

--- a/submit_cgap/tests/test_submission.py
+++ b/submit_cgap/tests/test_submission.py
@@ -12,16 +12,17 @@ from unittest import mock
 from .test_utils import shown_output
 from .test_upload_item_data import TEST_ENCRYPT_KEY
 from .. import submission as submission_module
+from .. import utils as utils_module
 from ..base import PRODUCTION_SERVER
 from ..exceptions import CGAPPermissionError
 from ..submission import (
     SERVER_REGEXP, get_defaulted_institution, get_defaulted_project, do_any_uploads, do_uploads, show_upload_info,
     execute_prearranged_upload, get_section, get_user_record, ingestion_submission_item_url,
-    resolve_server, resume_uploads, script_catch_errors, show_section, submit_any_ingestion,
+    resolve_server, resume_uploads, show_section, submit_any_ingestion,
     upload_file_to_uuid, upload_item_data, PROGRESS_CHECK_INTERVAL,
     get_s3_encrypt_key_id, get_s3_encrypt_key_id_from_health_page,
 )
-from ..utils import FakeResponse
+from ..utils import FakeResponse, script_catch_errors
 
 
 SOME_AUTH = ('my-key-id', 'good-secret')
@@ -331,7 +332,7 @@ def test_show_upload_info():
         assert auth == SOME_AUTH
         return FakeResponse(200, json=json_result)
 
-    with mock.patch.object(submission_module, "script_catch_errors", script_dont_catch_errors):
+    with mock.patch.object(utils_module, "script_catch_errors", script_dont_catch_errors):
         with mock.patch("requests.get", mocked_get):
 
             json_result = {}
@@ -578,7 +579,7 @@ def test_do_any_uploads():
 
     with mock.patch.object(submission_module, "do_uploads") as mock_uploads:
 
-        n_uploads = len(SOME_UPLOAD_INFO)
+        # n_uploads = len(SOME_UPLOAD_INFO)
 
         with shown_output() as shown:
             do_any_uploads(
@@ -599,7 +600,7 @@ def test_do_any_uploads():
 
 def test_resume_uploads():
 
-    with mock.patch.object(submission_module, "script_catch_errors", script_dont_catch_errors):
+    with mock.patch.object(utils_module, "script_catch_errors", script_dont_catch_errors):
         with mock.patch.object(submission_module, "resolve_server", return_value=SOME_SERVER):
             with mock.patch.object(submission_module, "get_keydict_for_server", return_value=SOME_KEYDICT):
                 some_response_json = {'some': 'json'}
@@ -616,7 +617,7 @@ def test_resume_uploads():
                             subfolders=False,
                         )
 
-    with mock.patch.object(submission_module, "script_catch_errors", script_dont_catch_errors):
+    with mock.patch.object(utils_module, "script_catch_errors", script_dont_catch_errors):
         with mock.patch.object(submission_module, "resolve_server", return_value=SOME_SERVER):
             with mock.patch.object(submission_module, "get_keydict_for_server", return_value=SOME_KEYDICT):
                 with mock.patch("requests.get", return_value=FakeResponse(401, json=SOME_BAD_RESULT)):
@@ -1001,7 +1002,7 @@ def test_upload_item_data():
 def test_submit_any_ingestion_old_protocol():
 
     with shown_output() as shown:
-        with mock.patch.object(submission_module, "script_catch_errors", script_dont_catch_errors):
+        with mock.patch.object(utils_module, "script_catch_errors", script_dont_catch_errors):
             with mock.patch.object(submission_module, "resolve_server", return_value=SOME_SERVER):
                 with mock.patch.object(submission_module, "yes_or_no", return_value=False):
                     try:
@@ -1102,7 +1103,7 @@ def test_submit_any_ingestion_old_protocol():
     # TODO: Will says he wants explanatory doc here and elsewhere with a big cascade like this.
     with mock.patch("os.path.exists", mfs.exists):
         with mock.patch("io.open", mfs.open):
-            with mock.patch.object(submission_module, "script_catch_errors", script_dont_catch_errors):
+            with mock.patch.object(utils_module, "script_catch_errors", script_dont_catch_errors):
                 with mock.patch.object(submission_module, "resolve_server", return_value=SOME_SERVER):
                     with mock.patch.object(submission_module, "yes_or_no", return_value=True):
                         with mock.patch.object(submission_module, "get_keydict_for_server",
@@ -1141,7 +1142,7 @@ def test_submit_any_ingestion_old_protocol():
             with mock.patch("io.open", mfs.open):
                 with io.open(SOME_BUNDLE_FILENAME, 'w') as fp:
                     print("Data would go here.", file=fp)
-                with mock.patch.object(submission_module, "script_catch_errors", script_dont_catch_errors):
+                with mock.patch.object(utils_module, "script_catch_errors", script_dont_catch_errors):
                     with mock.patch.object(submission_module, "resolve_server", return_value=SOME_SERVER):
                         with mock.patch.object(submission_module, "yes_or_no", return_value=True):
                             with mock.patch.object(submission_module, "get_keydict_for_server",
@@ -1202,7 +1203,7 @@ def test_submit_any_ingestion_old_protocol():
             with mock.patch("io.open", mfs.open):
                 with io.open(SOME_BUNDLE_FILENAME, 'w') as fp:
                     print("Data would go here.", file=fp)
-                with mock.patch.object(submission_module, "script_catch_errors", script_dont_catch_errors):
+                with mock.patch.object(utils_module, "script_catch_errors", script_dont_catch_errors):
                     with mock.patch.object(submission_module, "resolve_server", return_value=SOME_SERVER):
                         with mock.patch.object(submission_module, "get_keydict_for_server",
                                                return_value=SOME_KEYDICT):
@@ -1271,7 +1272,7 @@ def test_submit_any_ingestion_old_protocol():
             with mock.patch("io.open", mfs.open):
                 with io.open(SOME_BUNDLE_FILENAME, 'w') as fp:
                     print("Data would go here.", file=fp)
-                with mock.patch.object(submission_module, "script_catch_errors", script_dont_catch_errors):
+                with mock.patch.object(utils_module, "script_catch_errors", script_dont_catch_errors):
                     with mock.patch.object(submission_module, "resolve_server", return_value=SOME_SERVER):
                         with mock.patch.object(submission_module, "yes_or_no", return_value=True):
                             with mock.patch.object(submission_module, "get_keydict_for_server",
@@ -1324,7 +1325,7 @@ def test_submit_any_ingestion_old_protocol():
             with mock.patch("io.open", mfs.open):
                 with io.open(SOME_BUNDLE_FILENAME, 'w') as fp:
                     print("Data would go here.", file=fp)
-                with mock.patch.object(submission_module, "script_catch_errors", script_dont_catch_errors):
+                with mock.patch.object(utils_module, "script_catch_errors", script_dont_catch_errors):
                     with mock.patch.object(submission_module, "resolve_server", return_value=SOME_SERVER):
                         with mock.patch.object(submission_module, "yes_or_no", return_value=True):
                             with mock.patch.object(submission_module, "get_keydict_for_server",
@@ -1368,7 +1369,7 @@ def test_submit_any_ingestion_old_protocol():
             with mock.patch("io.open", mfs.open):
                 with io.open(SOME_BUNDLE_FILENAME, 'w') as fp:
                     print("Data would go here.", file=fp)
-                with mock.patch.object(submission_module, "script_catch_errors", script_dont_catch_errors):
+                with mock.patch.object(utils_module, "script_catch_errors", script_dont_catch_errors):
                     with mock.patch.object(submission_module, "resolve_server", return_value=SOME_SERVER):
                         with mock.patch.object(submission_module, "yes_or_no", return_value=True):
                             with mock.patch.object(submission_module, "get_keydict_for_server",
@@ -1423,7 +1424,7 @@ def test_submit_any_ingestion_old_protocol():
             with mock.patch("io.open", mfs.open):
                 with io.open(SOME_BUNDLE_FILENAME, 'w') as fp:
                     print("Data would go here.", file=fp)
-                with mock.patch.object(submission_module, "script_catch_errors", script_dont_catch_errors):
+                with mock.patch.object(utils_module, "script_catch_errors", script_dont_catch_errors):
                     with mock.patch.object(submission_module, "resolve_server", return_value=SOME_SERVER):
                         with mock.patch.object(submission_module, "yes_or_no", return_value=True):
                             with mock.patch.object(submission_module, "get_keydict_for_server",
@@ -1477,7 +1478,7 @@ def test_submit_any_ingestion_old_protocol():
             with mock.patch("io.open", mfs.open):
                 with io.open(SOME_BUNDLE_FILENAME, 'w') as fp:
                     print("Data would go here.", file=fp)
-                with mock.patch.object(submission_module, "script_catch_errors", script_dont_catch_errors):
+                with mock.patch.object(utils_module, "script_catch_errors", script_dont_catch_errors):
                     with mock.patch.object(submission_module, "resolve_server", return_value=SOME_SERVER):
                         with mock.patch.object(submission_module, "yes_or_no", return_value=True):
                             with mock.patch.object(submission_module, "get_keydict_for_server",
@@ -1535,7 +1536,7 @@ def test_submit_any_ingestion_old_protocol():
 def test_submit_any_ingestion_new_protocol():
 
     with shown_output() as shown:
-        with mock.patch.object(submission_module, "script_catch_errors", script_dont_catch_errors):
+        with mock.patch.object(utils_module, "script_catch_errors", script_dont_catch_errors):
             with mock.patch.object(submission_module, "resolve_server", return_value=SOME_SERVER):
                 with mock.patch.object(submission_module, "yes_or_no", return_value=False):
                     try:
@@ -1667,7 +1668,7 @@ def test_submit_any_ingestion_new_protocol():
 
     with mock.patch("os.path.exists", mfs.exists):
         with mock.patch("io.open", mfs.open):
-            with mock.patch.object(submission_module, "script_catch_errors", script_dont_catch_errors):
+            with mock.patch.object(utils_module, "script_catch_errors", script_dont_catch_errors):
                 with mock.patch.object(submission_module, "resolve_server", return_value=SOME_SERVER):
                     with mock.patch.object(submission_module, "yes_or_no", return_value=True):
                         with mock.patch.object(submission_module, "get_keydict_for_server",
@@ -1705,7 +1706,7 @@ def test_submit_any_ingestion_new_protocol():
             with mock.patch("io.open", mfs.open):
                 with io.open(SOME_BUNDLE_FILENAME, 'w') as fp:
                     print("Data would go here.", file=fp)
-                with mock.patch.object(submission_module, "script_catch_errors", script_dont_catch_errors):
+                with mock.patch.object(utils_module, "script_catch_errors", script_dont_catch_errors):
                     with mock.patch.object(submission_module, "resolve_server", return_value=SOME_SERVER):
                         with mock.patch.object(submission_module, "yes_or_no", return_value=True):
                             with mock.patch.object(submission_module, "get_keydict_for_server",
@@ -1776,7 +1777,7 @@ def test_submit_any_ingestion_new_protocol():
             with mock.patch("io.open", mfs.open):
                 with io.open(SOME_BUNDLE_FILENAME, 'w') as fp:
                     print("Data would go here.", file=fp)
-                with mock.patch.object(submission_module, "script_catch_errors", script_dont_catch_errors):
+                with mock.patch.object(utils_module, "script_catch_errors", script_dont_catch_errors):
                     with mock.patch.object(submission_module, "resolve_server", return_value=SOME_SERVER):
                         with mock.patch.object(submission_module, "yes_or_no", return_value=True):
                             with mock.patch.object(submission_module, "get_keydict_for_server",
@@ -1830,7 +1831,7 @@ def test_submit_any_ingestion_new_protocol():
             with mock.patch("io.open", mfs.open):
                 with io.open(SOME_BUNDLE_FILENAME, 'w') as fp:
                     print("Data would go here.", file=fp)
-                with mock.patch.object(submission_module, "script_catch_errors", script_dont_catch_errors):
+                with mock.patch.object(utils_module, "script_catch_errors", script_dont_catch_errors):
                     with mock.patch.object(submission_module, "resolve_server", return_value=SOME_SERVER):
                         with mock.patch.object(submission_module, "yes_or_no", return_value=True):
                             with mock.patch.object(submission_module, "get_keydict_for_server",
@@ -1875,7 +1876,7 @@ def test_submit_any_ingestion_new_protocol():
             with mock.patch("io.open", mfs.open):
                 with io.open(SOME_BUNDLE_FILENAME, 'w') as fp:
                     print("Data would go here.", file=fp)
-                with mock.patch.object(submission_module, "script_catch_errors", script_dont_catch_errors):
+                with mock.patch.object(utils_module, "script_catch_errors", script_dont_catch_errors):
                     with mock.patch.object(submission_module, "resolve_server", return_value=SOME_SERVER):
                         with mock.patch.object(submission_module, "yes_or_no", return_value=True):
                             with mock.patch.object(submission_module, "get_keydict_for_server",
@@ -1930,7 +1931,7 @@ def test_submit_any_ingestion_new_protocol():
             with mock.patch("io.open", mfs.open):
                 with io.open(SOME_BUNDLE_FILENAME, 'w') as fp:
                     print("Data would go here.", file=fp)
-                with mock.patch.object(submission_module, "script_catch_errors", script_dont_catch_errors):
+                with mock.patch.object(utils_module, "script_catch_errors", script_dont_catch_errors):
                     with mock.patch.object(submission_module, "resolve_server", return_value=SOME_SERVER):
                         with mock.patch.object(submission_module, "yes_or_no", return_value=True):
                             with mock.patch.object(submission_module, "get_keydict_for_server",
@@ -1984,7 +1985,7 @@ def test_submit_any_ingestion_new_protocol():
             with mock.patch("io.open", mfs.open):
                 with io.open(SOME_BUNDLE_FILENAME, 'w') as fp:
                     print("Data would go here.", file=fp)
-                with mock.patch.object(submission_module, "script_catch_errors", script_dont_catch_errors):
+                with mock.patch.object(utils_module, "script_catch_errors", script_dont_catch_errors):
                     with mock.patch.object(submission_module, "resolve_server", return_value=SOME_SERVER):
                         with mock.patch.object(submission_module, "yes_or_no", return_value=True):
                             with mock.patch.object(submission_module, "get_keydict_for_server",

--- a/submit_cgap/tests/test_submission.py
+++ b/submit_cgap/tests/test_submission.py
@@ -106,7 +106,15 @@ SOME_ENVIRON_WITH_CREDS = {
 
 @contextlib.contextmanager
 def script_dont_catch_errors():
+    # We use this to create a mock context that would allow us to catch errors that fall through here,
+    # but we are not relying on errors to actually happen, so it's OK if this never catches anything.
     yield
+
+
+def test_script_dont_catch_errors():  # test that errors pass through dont_catch_errors
+    with pytest.raises(AssertionError):
+        with script_dont_catch_errors():
+            raise AssertionError("Foo")
 
 
 def test_server_regexp():

--- a/submit_cgap/tests/test_submit_metadata_bundle.py
+++ b/submit_cgap/tests/test_submit_metadata_bundle.py
@@ -32,7 +32,7 @@ def test_submit_metadata_bundle_script(keyfile):
 
                     mock_submit_any_ingestion.side_effect = mocked_submit_metadata_bundle
                     submit_metadata_bundle_main(args_in)
-                    mock_submit_any_ingestion.assert_called_with(**expect_call_args)
+                    raise AssertionError("submit_metadata_bundle_main should not exit normally.")  # pragma: no cover
                 except SystemExit as e:
                     assert e.code == expect_exit_code
                 assert mock_submit_any_ingestion.call_count == (1 if expect_called else 0)

--- a/submit_cgap/tests/test_testing_helpers.py
+++ b/submit_cgap/tests/test_testing_helpers.py
@@ -1,0 +1,30 @@
+import pytest
+import re
+
+from dcicutils.qa_utils import raises_regexp
+from .testing_helpers import system_exit_expected
+
+
+def test_system_exit_expected():
+
+    with system_exit_expected(exit_code=0):
+        exit(0)
+
+    with system_exit_expected(exit_code=1):
+        exit(1)
+
+    with pytest.raises(AssertionError, match=re.escape("SystemExit got code=1 where code=0 was expected.")):
+        with system_exit_expected(exit_code=0):
+            exit(1)
+
+    with pytest.raises(AssertionError, match=re.escape("SystemExit got code=0 where code=1 was expected.")):
+        with system_exit_expected(exit_code=1):
+            exit(0)
+
+    with pytest.raises(AssertionError, match=re.escape("Expected SystemExit(0) but got unexpected error: foo")):
+        with system_exit_expected(exit_code=0):
+            raise RuntimeError("foo")
+
+    with pytest.raises(AssertionError, match=re.escape("Expected SystemExit(0) but got non-error exit.")):
+        with system_exit_expected(exit_code=0):
+            print("foo")  # no error

--- a/submit_cgap/tests/test_testing_helpers.py
+++ b/submit_cgap/tests/test_testing_helpers.py
@@ -1,7 +1,6 @@
 import pytest
 import re
 
-from dcicutils.qa_utils import raises_regexp
 from .testing_helpers import system_exit_expected
 
 

--- a/submit_cgap/tests/test_upload_item_data.py
+++ b/submit_cgap/tests/test_upload_item_data.py
@@ -45,7 +45,7 @@ def test_upload_item_data_script(keyfile, mocked_s3_encrypt_key_id):
 
                         mock_upload_item_data.side_effect = mocked_upload_item_data
                         upload_item_data_main(args_in)
-                        mock_upload_item_data.assert_called_with(**expect_call_args)
+                        raise AssertionError("upload_item_data_main should not exit normally.")  # pragma: no cover
                     assert mock_upload_item_data.call_count == (1 if expect_called else 0)
 
     test_it(args_in=[], expect_exit_code=2, expect_called=False)  # Missing args

--- a/submit_cgap/tests/test_upload_item_data.py
+++ b/submit_cgap/tests/test_upload_item_data.py
@@ -41,7 +41,8 @@ def test_upload_item_data_script(keyfile, mocked_s3_encrypt_key_id):
                             if KeyManager.keydicts_filename() == (keyfile or KeyManager.DEFAULT_KEYDICTS_FILENAME):
                                 exit(0)
                             else:
-                                exit(1)
+                                # This case is not expected to be reached but must be here for testing to catch
+                                exit(1)  # pragma: no cover
 
                         mock_upload_item_data.side_effect = mocked_upload_item_data
                         upload_item_data_main(args_in)

--- a/submit_cgap/tests/test_upload_item_data.py
+++ b/submit_cgap/tests/test_upload_item_data.py
@@ -8,6 +8,7 @@ from .. import submission as submission_module
 from ..base import KeyManager
 from ..scripts.upload_item_data import main as upload_item_data_main
 from ..scripts import upload_item_data as upload_item_data_module
+from .testing_helpers import system_exit_expected
 
 
 TEST_ENCRYPT_KEY = 'encrypt-key-for-testing'
@@ -26,7 +27,7 @@ def test_upload_item_data_script(keyfile, mocked_s3_encrypt_key_id):
 
                     mock_get_health_page.return_value = {HealthPageKey.S3_ENCRYPT_KEY_ID: mocked_s3_encrypt_key_id}
 
-                    try:
+                    with system_exit_expected(exit_code=expect_exit_code):
                         # Outside of the call, we will always see the default filename for cgap keys
                         # but inside the call, because of a decorator, the default might be different.
                         # See additional test below.
@@ -37,13 +38,14 @@ def test_upload_item_data_script(keyfile, mocked_s3_encrypt_key_id):
                             # We don't need to test this function's actions because we test its call args below.
                             # However, we do need to run this one test from the same dynamic context,
                             # so this is close enough.
-                            assert KeyManager.keydicts_filename() == (keyfile or KeyManager.DEFAULT_KEYDICTS_FILENAME)
+                            if KeyManager.keydicts_filename() == (keyfile or KeyManager.DEFAULT_KEYDICTS_FILENAME):
+                                exit(0)
+                            else:
+                                exit(1)
 
                         mock_upload_item_data.side_effect = mocked_upload_item_data
                         upload_item_data_main(args_in)
                         mock_upload_item_data.assert_called_with(**expect_call_args)
-                    except SystemExit as e:
-                        assert e.code == expect_exit_code
                     assert mock_upload_item_data.call_count == (1 if expect_called else 0)
 
     test_it(args_in=[], expect_exit_code=2, expect_called=False)  # Missing args

--- a/submit_cgap/tests/test_utils.py
+++ b/submit_cgap/tests/test_utils.py
@@ -4,7 +4,7 @@ import re
 
 from unittest import mock
 from .. import utils as utils_module
-from ..utils import show, keyword_as_title, FakeResponse
+from ..utils import show, keyword_as_title, FakeResponse, script_catch_errors
 
 
 @contextlib.contextmanager
@@ -107,3 +107,21 @@ def test_fake_response():
 
     with pytest.raises(Exception):
         error_response.raise_for_status()
+
+
+def test_script_catch_errors():
+
+    with shown_output() as shown:
+        with pytest.raises(SystemExit) as caught:
+            with script_catch_errors():
+                print("foo")
+        # foo = sys.exc_info()
+        assert caught.value.code == 0
+        assert shown.lines == []
+
+    with shown_output() as shown:
+        with pytest.raises(SystemExit) as caught:
+            with script_catch_errors():
+                raise Exception("Foo")
+        assert caught.value.code == 1
+        assert shown.lines == ["Exception: Foo"]

--- a/submit_cgap/tests/test_utils.py
+++ b/submit_cgap/tests/test_utils.py
@@ -2,6 +2,7 @@ import contextlib
 import pytest
 import re
 
+from dcicutils.misc_utils import override_environ, environ_bool
 from unittest import mock
 from .. import utils as utils_module
 from ..utils import show, keyword_as_title, FakeResponse, script_catch_errors
@@ -125,3 +126,25 @@ def test_script_catch_errors():
                 raise Exception("Foo")
         assert caught.value.code == 1
         assert shown.lines == ["Exception: Foo"]
+
+    # Not enough to override env var DEBUG_CGAP, since the module is already loaded and the env var's value
+    # is already seen and parsed. We must change module value at this point if we want to exercise the relevant
+    # code path.
+    with mock.patch.object(utils_module, "DEBUG_CGAP", True):
+        with shown_output() as shown:
+            with pytest.raises(Exception) as caught:
+                with script_catch_errors():
+                    raise Exception("Foo")
+            assert shown.lines == []  # The value was not trapped, so not shown
+
+    # Since we couldn't override the setting of the variable in the preceding code, we at least verify that setting
+    # the value would have produced the right effect.
+    with override_environ(DEBUG_CGAP=None):
+        assert not environ_bool("DEBUG_CGAP")  # Unset, the value is False
+    with override_environ(DEBUG_CGAP=""):
+        assert not environ_bool("DEBUG_CGAP")  # Set to empty string, the value is False
+    with override_environ(DEBUG_CGAP="FALSE"):
+        assert not environ_bool("DEBUG_CGAP")  # Set to "FALSE", the value is False
+    with override_environ(DEBUG_CGAP="TRUE"):
+        assert environ_bool("DEBUG_CGAP")      # Set to "TRUE", the value is True
+    # As it happens, random other values are false, but we just don't care about that.

--- a/submit_cgap/tests/test_utils.py
+++ b/submit_cgap/tests/test_utils.py
@@ -5,7 +5,7 @@ import re
 from dcicutils.misc_utils import override_environ, environ_bool
 from unittest import mock
 from .. import utils as utils_module
-from ..utils import show, keyword_as_title, FakeResponse, script_catch_errors
+from ..utils import show, keyword_as_title, FakeResponse, script_catch_errors, ERROR_HERALD
 
 
 @contextlib.contextmanager
@@ -125,7 +125,7 @@ def test_script_catch_errors():
             with script_catch_errors():
                 raise Exception("Foo")
         assert caught.value.code == 1
-        assert shown.lines == ["Exception: Foo"]
+        assert shown.lines == [ERROR_HERALD, "Exception: Foo"]
 
     # Not enough to override env var DEBUG_CGAP, since the module is already loaded and the env var's value
     # is already seen and parsed. We must change module value at this point if we want to exercise the relevant

--- a/submit_cgap/tests/testing_helpers.py
+++ b/submit_cgap/tests/testing_helpers.py
@@ -6,7 +6,8 @@ def system_exit_expected(*, exit_code):
     try:
         yield
     except SystemExit as e:
-        assert e.code == exit_code
+        if e.code != exit_code:
+            raise AssertionError(f"SystemExit got code={e.code} where code={exit_code} was expected.")
     except Exception as e:
         raise AssertionError(f"Expected SystemExit({exit_code}) but got unexpected error: {e}")
     else:

--- a/submit_cgap/tests/testing_helpers.py
+++ b/submit_cgap/tests/testing_helpers.py
@@ -1,0 +1,13 @@
+import contextlib
+
+
+@contextlib.contextmanager
+def system_exit_expected(*, exit_code):
+    try:
+        yield
+    except SystemExit as e:
+        assert e.code == exit_code
+    except Exception as e:
+        raise AssertionError(f"Expected SystemExit({exit_code}) but got unexpected error: {e}")
+    else:
+        raise AssertionError(f"Expected SystemExit({exit_code}) but got non-error exit.")

--- a/submit_cgap/utils.py
+++ b/submit_cgap/utils.py
@@ -64,6 +64,7 @@ class FakeResponse:
 
 DEBUG_CGAP = environ_bool("DEBUG_CGAP")
 
+
 @contextlib.contextmanager
 def script_catch_errors():
     try:

--- a/submit_cgap/utils.py
+++ b/submit_cgap/utils.py
@@ -1,7 +1,7 @@
 import contextlib
 import datetime
 
-from dcicutils.misc_utils import PRINT
+from dcicutils.misc_utils import PRINT, environ_bool
 from json import dumps as json_dumps, loads as json_loads
 
 
@@ -59,8 +59,10 @@ class FakeResponse:
 
     def raise_for_status(self):
         if self.status_code >= 300:
-            raise Exception("%s raised for status." % self)
+            raise Exception(f"{self} raised for status.")
 
+
+DEBUG_CGAP = environ_bool("DEBUG_CGAP")
 
 @contextlib.contextmanager
 def script_catch_errors():
@@ -68,5 +70,9 @@ def script_catch_errors():
         yield
         exit(0)
     except Exception as e:
-        show("%s: %s" % (e.__class__.__name__, str(e)))
-        exit(1)
+        if DEBUG_CGAP:
+            # If debugging, let the error propagate, do not trap it.
+            raise
+        else:
+            show(f"{e.__class__.__name__}: {e}")
+            exit(1)

--- a/submit_cgap/utils.py
+++ b/submit_cgap/utils.py
@@ -1,3 +1,4 @@
+import contextlib
 import datetime
 
 from dcicutils.misc_utils import PRINT
@@ -59,3 +60,13 @@ class FakeResponse:
     def raise_for_status(self):
         if self.status_code >= 300:
             raise Exception("%s raised for status." % self)
+
+
+@contextlib.contextmanager
+def script_catch_errors():
+    try:
+        yield
+        exit(0)
+    except Exception as e:
+        show("%s: %s" % (e.__class__.__name__, str(e)))
+        exit(1)

--- a/submit_cgap/utils.py
+++ b/submit_cgap/utils.py
@@ -64,6 +64,8 @@ class FakeResponse:
 
 DEBUG_CGAP = environ_bool("DEBUG_CGAP")
 
+ERROR_HERALD = "Command exited in an unusual way. Please feel free to report this, citing the following message."
+
 
 @contextlib.contextmanager
 def script_catch_errors():
@@ -75,5 +77,6 @@ def script_catch_errors():
             # If debugging, let the error propagate, do not trap it.
             raise
         else:
+            show(ERROR_HERALD)
             show(f"{e.__class__.__name__}: {e}")
             exit(1)


### PR DESCRIPTION
This regularizes the use of `script_catch_errors` to suppress tracebacks by default around SubmitCGAP commands, per [SubmitCGAP should not show traceback info by default (C4-790)](https://hms-dbmi.atlassian.net/browse/C4-790).