### PR TITLE
Fix residual SubmitCGAP problem (C4-818)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,10 +7,16 @@ Change Log
 ----------
 
 
+1.4.2
+=====
+
+* Further adustments to repair problems created by 1.4.1 (C4-818).
+
+
 1.4.1
 =====
 
-* Fix SubmitCGAP file upload to work correctly under Microsoft/Windows 10.
+* Fix SubmitCGAP file upload to work correctly under Microsoft/Windows 10 (C4-816).
 
 
 1.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "submit_cgap"
-version = "1.4.1"
+version = "1.4.1.0b0"
 description = "Support for uploading file submissions to the Clinical Genomics Analysis Platform (CGAP)."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "submit_cgap"
-version = "1.4.1.1b0"
+version = "1.4.2"
 description = "Support for uploading file submissions to the Clinical Genomics Analysis Platform (CGAP)."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "submit_cgap"
-version = "1.4.1.0b0"
+version = "1.4.1.1b0"
 description = "Support for uploading file submissions to the Clinical Genomics Analysis Platform (CGAP)."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/submit_cgap/submission.py
+++ b/submit_cgap/submission.py
@@ -565,13 +565,20 @@ def execute_prearranged_upload(path, upload_credentials, auth=None):
             PRINT(f"Executing: {command}")
             PRINT(f" ==> {' '.join(command)}")
             PRINT(f"Environment variables include {conjoined_list(list(extra_env.keys()))}.")
-        subprocess.check_call(command, env=env, shell=True)
+        options = {}
+        if running_on_windows_native():
+            options = {"shell": True}
+        subprocess.check_call(command, env=env, **options)
     except subprocess.CalledProcessError as e:
         raise RuntimeError("Upload failed with exit code %d" % e.returncode)
     else:
         end = time.time()
         duration = end - start
         show("Uploaded in %.2f seconds" % duration)
+
+
+def running_on_windows_native():
+    return os.name == 'nt'
 
 
 def upload_file_to_uuid(filename, uuid, auth):

--- a/submit_cgap/tests/test_submission.py
+++ b/submit_cgap/tests/test_submission.py
@@ -124,7 +124,13 @@ def _independently_confirmed_as_running_on_windows_native():
     #    os.name == 'nt' (as opposed to 'posix')
     #    platform.system() == 'Windows' (as opposed to 'Linux', 'Darwin', or 'CYGWIN_NT-<version>'
     # Since we're wanting to test one of these, we  use the other mechansim to confirm things.
-    return platform.system() == 'Windows'
+    standard_result = running_on_windows_native()
+    independent_result = platform.system() == 'Windows'
+    assert standard_result == independent_result, (
+        f"Mechanisms for telling whether we're on Windows disagree:"
+        f" standard_result={standard_result} independent_result={independent_result}"
+    )
+    return independent_result
 
 
 @contextlib.contextmanager

--- a/submit_cgap/tests/test_submission.py
+++ b/submit_cgap/tests/test_submission.py
@@ -4,7 +4,6 @@ import os
 import platform
 import pytest
 import re
-import sys
 
 from dcicutils.qa_utils import (
     override_environ, ignored, ControlledTime, MockFileSystem, local_attrs, raises_regexp, printed_output,
@@ -736,7 +735,8 @@ def test_execute_prearranged_upload(os_simulation_mode: str):
             with shown_output() as shown:
                 with mock.patch("time.time", MockTime().time):
                     with mock.patch("subprocess.call", return_value=0) as mock_aws_call:
-                        execute_prearranged_upload(path=SOME_FILENAME, upload_credentials=SOME_EXTENDED_UPLOAD_CREDENTIALS)
+                        execute_prearranged_upload(path=SOME_FILENAME,
+                                                   upload_credentials=SOME_EXTENDED_UPLOAD_CREDENTIALS)
                         mock_aws_call.assert_called_with(
                             ['aws', 's3', 'cp',
                              '--sse', 'aws:kms', '--sse-kms-key-id', SOME_S3_ENCRYPT_KEY_ID,

--- a/submit_cgap/tests/test_submission.py
+++ b/submit_cgap/tests/test_submission.py
@@ -1,6 +1,7 @@
 import contextlib
 import io
 import os
+import platform
 import pytest
 import re
 
@@ -20,7 +21,7 @@ from ..submission import (
     execute_prearranged_upload, get_section, get_user_record, ingestion_submission_item_url,
     resolve_server, resume_uploads, show_section, submit_any_ingestion,
     upload_file_to_uuid, upload_item_data, PROGRESS_CHECK_INTERVAL,
-    get_s3_encrypt_key_id, get_s3_encrypt_key_id_from_health_page,
+    get_s3_encrypt_key_id, get_s3_encrypt_key_id_from_health_page, running_on_windows_native,
 )
 from ..utils import FakeResponse, script_catch_errors, ERROR_HERALD
 
@@ -116,6 +117,14 @@ SOME_ENVIRON_WITH_CREDS = {
     'AWS_SECRET_ACCESS_KEY': 'some-secret',
     'AWS_SECURITY_TOKEN': 'some-session-token',
 }
+
+
+def _independently_confirmed_as_running_on_windows_native():
+    # There are two ways to tell if we're running on Windows native:
+    #    os.name == 'nt' (as opposed to 'posix')
+    #    platform.system() == 'Windows' (as opposed to 'Linux', 'Darwin', or 'CYGWIN_NT-<version>'
+    # Since we're wanting to test one of these, we  use the other mechansim to confirm things.
+    return platform.system() == 'Windows'
 
 
 @contextlib.contextmanager
@@ -670,6 +679,10 @@ def test_execute_prearranged_upload():
                 execute_prearranged_upload('this-file-name-is-not-used', bad_credentials)
             assert shown.lines == []
 
+    subprocess_options = {}
+    if _independently_confirmed_as_running_on_windows_native():
+        subprocess_options = {'shell': True}
+
     with mock.patch.object(os, "environ", SOME_ENVIRON.copy()):
         with shown_output() as shown:
             with mock.patch("time.time", MockTime().time):
@@ -678,7 +691,7 @@ def test_execute_prearranged_upload():
                     mock_aws_call.assert_called_with(
                         ['aws', 's3', 'cp', '--only-show-errors', SOME_FILENAME, SOME_UPLOAD_URL],
                         env=SOME_ENVIRON_WITH_CREDS,
-                        shell=True,
+                        **subprocess_options
                     )
                     assert shown.lines == [
                         "Going to upload some-filename to some-url.",
@@ -695,7 +708,7 @@ def test_execute_prearranged_upload():
                          '--sse', 'aws:kms', '--sse-kms-key-id', SOME_S3_ENCRYPT_KEY_ID,
                          '--only-show-errors', SOME_FILENAME, SOME_UPLOAD_URL],
                         env=SOME_ENVIRON_WITH_CREDS,
-                        shell=True,
+                        **subprocess_options
                     )
                     assert shown.lines == [
                         "Going to upload some-filename to some-url.",
@@ -711,7 +724,7 @@ def test_execute_prearranged_upload():
                     mock_aws_call.assert_called_with(
                         ['aws', 's3', 'cp', '--only-show-errors', SOME_FILENAME, SOME_UPLOAD_URL],
                         env=SOME_ENVIRON_WITH_CREDS,
-                        shell=True,
+                        **subprocess_options
                     )
                     assert shown.lines == [
                         "Going to upload some-filename to some-url.",
@@ -2148,3 +2161,10 @@ def test_submit_any_ingestion_new_protocol():
             # After 1 second to recheck the time...
             '12:02:10 Timed out after 8 tries.',
         ]
+
+
+def test_running_on_windows_native():
+    for pair in [("nt", True), ("posix", False)]:
+        os_name, is_windows = pair
+        with mock.patch.object(os, "name", os_name):
+            assert running_on_windows_native() is is_windows


### PR DESCRIPTION
Doug was having problems with the SubmitCGAP fix for windows in MacOS (even though Sarah tested it). So I'm splitting the difference and making it be conditional on platform type, passing `shell=True` only in the case of Windows, not MacOS.