### PR TITLE
Adding check-submit command

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -471,14 +471,14 @@ tox = ["tox"]
 
 [[package]]
 name = "dcicutils"
-version = "7.3.2.1b2"
+version = "7.4.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 category = "main"
 optional = false
 python-versions = ">=3.7,<3.10"
 files = [
-    {file = "dcicutils-7.3.2.1b2-py3-none-any.whl", hash = "sha256:84944b9a876922db51e5c5ff88a9c8d2491c346e2b8882ec7ccc9830fa4fd77f"},
-    {file = "dcicutils-7.3.2.1b2.tar.gz", hash = "sha256:526a1debbfa7771c92f060fb4dc63cd93a585f342f6709220e56abe2609eb616"},
+    {file = "dcicutils-7.4.1-py3-none-any.whl", hash = "sha256:eafacedee6845387cff54ef1760a43d264fc52422af5259b3cc0f97d580c3c25"},
+    {file = "dcicutils-7.4.1.tar.gz", hash = "sha256:9c939a450e4c5446922188fa7e3b9f7fb92e698a40f96af560dc7b52bbc7668c"},
 ]
 
 [package.dependencies]
@@ -1610,4 +1610,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7.0,<3.10"
-content-hash = "4b659dea4eb6ba1e4a5737ef577e93cb4044dbea374714b8e45d711d61d6356c"
+content-hash = "7722b539205485457bf3baf620c745f2ed56f7698895a8e2e6b77afb0bdcb59c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,7 @@ python = ">=3.7.0,<3.10"
 
 awscli = "^1.27.79"
 # boto3 = "^1.26.79"
-#dcicutils = "6.10.1.1b1"
-dcicutils = "7.3.2.1b2"
+dcicutils = "^7.4.0"
 requests = "^2.28.2"
 
 [tool.poetry.dev-dependencies]
@@ -91,6 +90,7 @@ submit-metadata-bundle = "submit_cgap.scripts.submit_metadata_bundle:main"
 upload-item-data = "submit_cgap.scripts.upload_item_data:main"
 submit-genelist = "submit_cgap.scripts.submit_genelist:main"
 submit-ontology = "submit_cgap.scripts.submit_ontology:main"
+check-submit= "submit_cgap.scripts.check_submit:main"
 
 [tool.coverage.report]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ submit-metadata-bundle = "submit_cgap.scripts.submit_metadata_bundle:main"
 upload-item-data = "submit_cgap.scripts.upload_item_data:main"
 submit-genelist = "submit_cgap.scripts.submit_genelist:main"
 submit-ontology = "submit_cgap.scripts.submit_ontology:main"
-check-submit= "submit_cgap.scripts.check_submit:main"
+check-ontoloy= "submit_cgap.ontoloy.check_ontoloy:main"
 
 [tool.coverage.report]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ submit-metadata-bundle = "submit_cgap.scripts.submit_metadata_bundle:main"
 upload-item-data = "submit_cgap.scripts.upload_item_data:main"
 submit-genelist = "submit_cgap.scripts.submit_genelist:main"
 submit-ontology = "submit_cgap.scripts.submit_ontology:main"
-check-ontoloy= "submit_cgap.scripts.check_ontology:main"
+check-submission= "submit_cgap.scripts.check_submission:main"
 
 [tool.coverage.report]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ submit-metadata-bundle = "submit_cgap.scripts.submit_metadata_bundle:main"
 upload-item-data = "submit_cgap.scripts.upload_item_data:main"
 submit-genelist = "submit_cgap.scripts.submit_genelist:main"
 submit-ontology = "submit_cgap.scripts.submit_ontology:main"
-check-ontoloy= "submit_cgap.ontoloy.check_ontoloy:main"
+check-ontoloy= "submit_cgap.scripts.check_ontology:main"
 
 [tool.coverage.report]
 

--- a/submit_cgap/scripts/check_ontology.py
+++ b/submit_cgap/scripts/check_ontology.py
@@ -1,0 +1,39 @@
+import argparse
+import json
+import io
+import os
+from dcicutils.common import APP_FOURFRONT, ORCHESTRATED_APPS
+from dcicutils.command_utils import ScriptFailure
+from dcicutils.misc_utils import get_error_message
+from ..submission import check_submit_ingestion, SubmissionProtocol, SUBMISSION_PROTOCOLS
+from ..utils import script_catch_errors, show
+
+
+EPILOG = __doc__
+
+
+def main():
+    parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
+        description="Check previously submitted ontology",
+        epilog=EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument('submission_uuid', help='uuid of previously submitted ontology')
+    parser.add_argument('--app', choices=ORCHESTRATED_APPS, default=APP_FOURFRONT,
+                        help=f"An application (default {APP_FOURFRONT!r}. Only for debugging."
+                             f" Normally this should not be given.")
+    parser.add_argument('--server', '-s', help="an http or https address of the server to use", default=None)
+    parser.add_argument('--env', '-e', help="a CGAP beanstalk environment name for the server to use", default=None)
+    args = parser.parse_args()
+
+    with script_catch_errors():
+        return check_submit_ingestion(
+                args.submission_uuid,
+                server=args.server,
+                env=args.env,
+                app=args.app
+        )
+
+
+if __name__ == '__main__':
+    main()

--- a/submit_cgap/scripts/check_ontology.py
+++ b/submit_cgap/scripts/check_ontology.py
@@ -1,12 +1,7 @@
 import argparse
-import json
-import io
-import os
 from dcicutils.common import APP_FOURFRONT, ORCHESTRATED_APPS
-from dcicutils.command_utils import ScriptFailure
-from dcicutils.misc_utils import get_error_message
-from ..submission import check_submit_ingestion, SubmissionProtocol, SUBMISSION_PROTOCOLS
-from ..utils import script_catch_errors, show
+from ..submission import check_submit_ingestion
+from ..utils import script_catch_errors
 
 
 EPILOG = __doc__

--- a/submit_cgap/scripts/check_submission.py
+++ b/submit_cgap/scripts/check_submission.py
@@ -9,11 +9,11 @@ EPILOG = __doc__
 
 def main():
     parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
-        description="Check previously submitted ontology",
+        description="Check previously submitted submission.",
         epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    parser.add_argument('submission_uuid', help='uuid of previously submitted ontology')
+    parser.add_argument('submission_uuid', help='uuid of previously submitted submission.')
     parser.add_argument('--app', choices=ORCHESTRATED_APPS, default=APP_FOURFRONT,
                         help=f"An application (default {APP_FOURFRONT!r}. Only for debugging."
                              f" Normally this should not be given.")

--- a/submit_cgap/scripts/check_submission.py
+++ b/submit_cgap/scripts/check_submission.py
@@ -1,5 +1,6 @@
 import argparse
-from dcicutils.common import APP_FOURFRONT, ORCHESTRATED_APPS
+from dcicutils.common import APP_CGAP, ORCHESTRATED_APPS
+from dcicutils.env_utils import EnvUtils
 from ..submission import check_submit_ingestion
 from ..utils import script_catch_errors
 
@@ -7,19 +8,26 @@ from ..utils import script_catch_errors
 EPILOG = __doc__
 
 
-def main():
+def default_app_for_check_submission():
+    EnvUtils.init()
+    return EnvUtils.app_name()
+
+
+def main(simulated_args_for_testing=None):
+    default_app = default_app_for_check_submission()
+
     parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Check previously submitted submission.",
         epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument('submission_uuid', help='uuid of previously submitted submission.')
-    parser.add_argument('--app', choices=ORCHESTRATED_APPS, default=APP_FOURFRONT,
-                        help=f"An application (default {APP_FOURFRONT!r}. Only for debugging."
+    parser.add_argument('--app', choices=ORCHESTRATED_APPS, default=default_app,
+                        help=f"An application (default {default_app!r}. Only for debugging."
                              f" Normally this should not be given.")
     parser.add_argument('--server', '-s', help="an http or https address of the server to use", default=None)
     parser.add_argument('--env', '-e', help="a CGAP beanstalk environment name for the server to use", default=None)
-    args = parser.parse_args()
+    args = parser.parse_args(args=simulated_args_for_testing)
 
     with script_catch_errors():
         return check_submit_ingestion(

--- a/submit_cgap/scripts/check_submission.py
+++ b/submit_cgap/scripts/check_submission.py
@@ -1,5 +1,5 @@
 import argparse
-from dcicutils.common import APP_CGAP, ORCHESTRATED_APPS
+from dcicutils.common import ORCHESTRATED_APPS
 from dcicutils.env_utils import EnvUtils
 from ..submission import check_submit_ingestion
 from ..utils import script_catch_errors

--- a/submit_cgap/scripts/submit_ontology.py
+++ b/submit_cgap/scripts/submit_ontology.py
@@ -56,7 +56,7 @@ def verify_ontology_file(ontology_filename: str) -> bool:
     try:
         with io.open(ontology_filename, "r") as f:
             ontology_json = json.load(f)
-            ontology_term_count = len(ontology_json["ontology_term"])  # xyzzy
+            ontology_term_count = len(ontology_json["ontology_term"])
     except Exception as e:
         raise ScriptFailure(f"Cannot load specified ontology (JSON) file: {ontology_filename} | {get_error_message(e)}")
     show(f"Verified specified ontology (JSON) file: {ontology_filename} (ontology terms: {ontology_term_count})")

--- a/submit_cgap/submission.py
+++ b/submit_cgap/submission.py
@@ -264,9 +264,6 @@ def do_app_arg_defaulting(app_args, user_record):
 
 PROGRESS_CHECK_INTERVAL = 15  # seconds
 ATTEMPTS_BEFORE_TIMEOUT = 40
-#xyzzy
-PROGRESS_CHECK_INTERVAL = 1  # seconds
-ATTEMPTS_BEFORE_TIMEOUT = 2
 
 
 def get_section(res, section):
@@ -448,8 +445,6 @@ def submit_any_ingestion(ingestion_filename, *, ingestion_type, server, env, val
                          institution=None, project=None, lab=None, award=None, app: OrchestratedApp = None,
                          upload_folder=None, no_query=False, subfolders=False,
                          submission_protocol=DEFAULT_SUBMISSION_PROTOCOL):
-    print('xyzzy/........')
-    print(env)
     """
     Does the core action of submitting a metadata bundle.
 
@@ -588,55 +583,10 @@ def submit_any_ingestion(ingestion_filename, *, ingestion_type, server, env, val
 
     check_done, check_status, check_response = check_submit_ingestion(uuid, server, env, app)
 
-#   def check_ingestion_progress():
-#       """
-#       Calls endpoint to get this status of the IngestionSubmission uuid (in outer scope);
-#       this is used as an argument to check_repeatedly below to call over and over.
-#       Returns tuple with: done-indicator (True or False), short-status (str), full-response (dict)
-#       From outer scope: server, keypair, uuid (of IngestionSubmission)
-#       """
-#       tracking_url = ingestion_submission_item_url(server=server, uuid=uuid)
-#       response = portal_request_get(tracking_url, auth=keypair, headers=STANDARD_HTTP_HEADERS).json()
-#       # FYI this processing_status and its state, progress, outcome properties were ultimately set
-#       # from within the ingester process, from within types.ingestion.SubmissionFolio.processing_status.
-#       status = response["processing_status"]
-#       if status.get("state") == "done":
-#           outcome = status["outcome"]
-#           return True, outcome, response
-#       else:
-#           progress = status["progress"]
-#           return False, progress, response
-
-#   # Check the ingestion processing repeatedly, up to ATTEMPTS_BEFORE_TIMEOUT times,
-#   # and waiting PROGRESS_CHECK_INTERVAL seconds between each check.
-#   [check_done, check_status, check_response] = (
-#       check_repeatedly(check_ingestion_progress,
-#                        wait_seconds=PROGRESS_CHECK_INTERVAL,
-#                        repeat_count=ATTEMPTS_BEFORE_TIMEOUT)
-#   )
-#
-#   if not check_done:
-#       show("Exiting after check processing timeout | Check status using: TODO")
-#       exit(1)
-#
-#   show("Final status: %s" % check_status.title(), with_time=True)
-#
-#   if check_status == "error" and check_response.get("errors"):
-#       show_section(check_response, "errors")
-#
-#   caveat_check_status = None if check_status == "success" else check_status
-#   show_section(check_response, "validation_output", caveat_outcome=caveat_check_status)
-#
-#   if validate_only:
-#       exit(0)
-#
-#   show_section(check_response, "post_output", caveat_outcome=caveat_check_status)
-
     if validate_only:
         exit(0)
 
     if check_status == "success":
-        show_section(check_response, "upload_info")
         do_any_uploads(check_response, keydict=keydict, ingestion_filename=ingestion_filename,
                        upload_folder=upload_folder, no_query=no_query,
                        subfolders=subfolders)
@@ -704,11 +654,6 @@ def check_submit_ingestion(uuid: str, server: str, env: str, app: OrchestratedAp
 
     if check_status == "success":
         show_section(check_response, "upload_info")
-        # Note that for check-submit we do not currently do this part where we
-        # upload the ingestion file AFTER the main part of the submission is complete.
-        # do_any_uploads(check_response, keydict=keydict, ingestion_filename=ingestion_filename,
-        #                upload_folder=upload_folder, no_query=no_query,
-        #                subfolders=subfolders)
 
     return check_done, check_status, check_response
 

--- a/submit_cgap/submission.py
+++ b/submit_cgap/submission.py
@@ -253,7 +253,7 @@ def get_defaulted_consortia(consortia, user_record, error_if_none=False):
     consortia = consortia
     if not consortia:
         consortia = [consortium.get('@id', None)
-                     for consortium in user_record.get('consortia', {})]
+                     for consortium in user_record.get('consortia', [])]
         if not consortia:
             if error_if_none:
                 raise SyntaxError("Your user profile has no consortium declared,"

--- a/submit_cgap/submission.py
+++ b/submit_cgap/submission.py
@@ -613,7 +613,8 @@ def submit_any_ingestion(ingestion_filename, *, ingestion_type, server, env, val
     exit(0)
 
 
-def check_submit_ingestion(uuid: str, server: str, env: str, app: OrchestratedApp = None) -> Tuple[bool, str, dict]:
+def check_submit_ingestion(uuid: str, server: str, env: str,
+                           app: Optional[OrchestratedApp] = None) -> Tuple[bool, str, dict]:
 
     if app is None:  # For legacy reasons, SubmitCGAP was the first so didn't expect this arg was needed
         app = DEFAULT_APP

--- a/submit_cgap/submission.py
+++ b/submit_cgap/submission.py
@@ -233,7 +233,6 @@ def get_defaulted_lab(lab, user_record, error_if_none=False):
             if error_if_none:
                 raise SyntaxError("Your user profile has no lab declared,"
                                   " so you must specify --lab explicitly.")
-        if not lab:
             show("No lab was inferred.")
         else:
             show("Using inferred lab:", lab)
@@ -242,11 +241,63 @@ def get_defaulted_lab(lab, user_record, error_if_none=False):
     return lab
 
 
+def get_defaulted_consortia(consortia, user_record, error_if_none=False):
+    """
+    Returns the given consortia or else if none is specified, it tries to infer any consortia.
+
+    :param consortia: a list of @id's of consortia, or None
+    :param user_record: the user record for the authorized user
+    :param error_if_none: boolean true if failure to infer any consortia should raise an error, and false otherwise.
+    :return: the @id of a consortium to use (or a comma-separated list)
+    """
+    consortia = consortia
+    if not consortia:
+        consortia = [consortium.get('@id', None)
+                     for consortium in user_record.get('consortia', {})]
+        if not consortia:
+            if error_if_none:
+                raise SyntaxError("Your user profile has no consortium declared,"
+                                  " so you must specify --consortium explicitly.")
+            show("No consortium was inferred.")
+        else:
+            show("Using inferred consortium:", ','.join(consortia))
+    else:
+        show("Using given consortium:", ','.join(consortia))
+    return consortia
+
+
+def get_defaulted_submission_centers(submission_centers, user_record, error_if_none=False):
+    """
+    Returns the given submission center or else if none is specified, it tries to infer a submission center.
+
+    :param submission_centers: the @id of a submission center, or None
+    :param user_record: the user record for the authorized user
+    :param error_if_none: boolean true if failure to infer a submission center should raise an error,
+        and false otherwise.
+    :return: the @id of a submission center to use
+    """
+    if not submission_centers:
+        submission_centers = [submission_center.get('@id', None)
+                              for submission_center in user_record.get('submission_centers', {})]
+        if not submission_centers:
+            if error_if_none:
+                raise SyntaxError("Your user profile has no submission center declared,"
+                                  " so you must specify --submission-center explicitly.")
+            show("No submission center was inferred.")
+        else:
+            show("Using inferred submission center:", submission_centers)
+    else:
+        show("Using given submission center:", submission_centers)
+    return submission_centers
+
+
 APP_ARG_DEFAULTERS = {
     'institution': get_defaulted_institution,
     'project': get_defaulted_project,
     'lab': get_defaulted_lab,
     'award': get_defaulted_award,
+    'consortia': get_defaulted_consortia,
+    'submission_centers': get_defaulted_submission_centers,
 }
 
 

--- a/submit_cgap/submission.py
+++ b/submit_cgap/submission.py
@@ -707,10 +707,7 @@ def check_submit_ingestion(uuid: str, server: str, env: str,
     )
 
     if not check_done:
-        if env:
-            command_summary = f"check-submit --app {app} --env {env} {uuid}"
-        else:
-            command_summary = f"check-submit --app {app} --server {server} {uuid}"
+        command_summary = summarize_submission(uuid=uuid, server=server, env=env, app=app)
         show(f"Exiting after check processing timeout using {command_summary!r}.")
         exit(1)
 
@@ -727,6 +724,16 @@ def check_submit_ingestion(uuid: str, server: str, env: str,
         show_section(check_response, "upload_info")
 
     return check_done, check_status, check_response
+
+
+def summarize_submission(uuid: str, app: str, server: Optional[str] = None, env: Optional[str] = None):
+    if env:
+        command_summary = f"check-submit --app {app} --env {env} {uuid}"
+    elif server:
+        command_summary = f"check-submit --app {app} --server {server} {uuid}"
+    else:  # unsatisfying, but not worth raising an error
+        command_summary = f"check-submit --app {app} {uuid}"
+    return command_summary
 
 
 def compute_s3_submission_post_data(ingestion_filename, ingestion_post_result, **other_args):

--- a/submit_cgap/tests/test_base.py
+++ b/submit_cgap/tests/test_base.py
@@ -2,8 +2,8 @@ import contextlib
 import pytest
 import re
 
-from dcicutils.common import APP_CGAP, APP_FOURFRONT
-from dcicutils.creds_utils import CGAPKeyManager, FourfrontKeyManager, KeyManager
+from dcicutils.common import APP_CGAP, APP_FOURFRONT, APP_SMAHT
+from dcicutils.creds_utils import CGAPKeyManager, FourfrontKeyManager, SMaHTKeyManager, KeyManager
 from dcicutils.misc_utils import override_environ
 from unittest import mock
 from .. import base as base_module
@@ -55,6 +55,13 @@ def test_generic_key_manager():
         manager.select_app(invalid_app)
 
     with manager.locally_selected_app(APP_CGAP):
+        assert manager.selected_app == APP_CGAP
+        assert isinstance(key_manager(manager), CGAPKeyManager)
+
+        with manager.locally_selected_app(APP_SMAHT):
+            assert manager.selected_app == APP_SMAHT
+            assert isinstance(key_manager(manager), SMaHTKeyManager)
+
         assert manager.selected_app == APP_CGAP
         assert isinstance(key_manager(manager), CGAPKeyManager)
 

--- a/submit_cgap/tests/test_check_submission.py
+++ b/submit_cgap/tests/test_check_submission.py
@@ -1,0 +1,66 @@
+from unittest import mock
+
+from dcicutils.common import ORCHESTRATED_APPS
+from dcicutils.misc_utils import ignored
+from ..scripts.check_submission import main as check_submission_main, default_app_for_check_submission
+from ..scripts import check_submission as check_submission_module
+from .testing_helpers import system_exit_expected
+
+
+SAMPLE_GUID = '1f199b61-e7a1-4c2a-9599-cfc64f51dab7'
+
+
+def test_check_submission_script():
+
+    default_app = default_app_for_check_submission()
+
+    def test_it(args_in, expect_exit_code, expect_called, expect_call_args=None):
+        ignored(expect_call_args)
+        with mock.patch.object(check_submission_module, "check_submit_ingestion") as mock_check_submit_ingestion:
+            with system_exit_expected(exit_code=expect_exit_code):
+                check_submission_main(args_in)
+                raise AssertionError("check_submission_main should not exit normally.")  # pragma: no cover
+            assert mock_check_submit_ingestion.call_count == (1 if expect_called else 0)
+
+    test_it(args_in=[], expect_exit_code=2, expect_called=False)  # Missing args
+    test_it(args_in=[SAMPLE_GUID], expect_exit_code=0, expect_called=True,
+            expect_call_args={
+                'submission_uuid': SAMPLE_GUID,
+                'app': default_app,
+                'server': None,
+                'env': None,
+            })
+    sample_app = None
+    for app in ORCHESTRATED_APPS:
+        if app != default_app:
+            sample_app = app
+    assert sample_app, "sample_app did not get properly set."
+    sample_server = 'https://cgap-foo'
+    sample_env = 'cgap-foo'
+    test_it(args_in=['--server', sample_server, SAMPLE_GUID],
+            expect_exit_code=0,
+            expect_called=True,
+            expect_call_args={
+                'submission_uuid': SAMPLE_GUID,
+                'app': default_app,
+                'server': sample_server,
+                'env': None,
+            })
+    test_it(args_in=[SAMPLE_GUID, '--server', sample_server, '--app', sample_app],
+            expect_exit_code=0,
+            expect_called=True,
+            expect_call_args={
+                'submission_uuid': SAMPLE_GUID,
+                'app': sample_app,  # unadvisable but possible. documented as being only for debugging
+                'server': sample_server,
+                'env': None,
+            })
+    test_it(args_in=[SAMPLE_GUID, '--env', sample_env],
+            expect_exit_code=0,
+            expect_called=True,
+            expect_call_args={
+                'submission_uuid': SAMPLE_GUID,
+                'app': default_app,
+                'server': None,
+                'env': sample_env,
+            })

--- a/submit_cgap/tests/test_submission.py
+++ b/submit_cgap/tests/test_submission.py
@@ -354,7 +354,7 @@ def test_get_defaulted_institution():
                                                   user_record=make_user_record(
                                                       # this is the old-fashioned place for it - a decoy
                                                       institution={'@id': SOME_OTHER_INSTITUTION},
-                                                      # this is the right place to find he info
+                                                      # this is the right place to find the info
                                                       user_institution={'@id': SOME_INSTITUTION}
                                                   ))
 
@@ -561,7 +561,7 @@ def test_show_upload_result():
                         show_validation_output=False,
                         show_processing_status=True,
                         show_datafile_url=False)
-                    # Heading is shown if there are an times, so that's the +1
+                    # Heading is shown if there are n times, so that's the +1
                     # Otherwise one output line is shown for each non-null item
                     assert len(shown.lines) == 0 if n == 0 else n + 1
 
@@ -1342,8 +1342,7 @@ class Scenario:
 
     def make_uploaded_lines(self):
         uploaded_time = self.get_time_after_wait()
-        result = []
-        result.append(f"The server {SOME_SERVER} recognizes you as: J Doe <jdoe@cgap.hms.harvard.edu>")
+        result = [f"The server {SOME_SERVER} recognizes you as: J Doe <jdoe@cgap.hms.harvard.edu>"]
         if submission_module.DEBUG_PROTOCOL:  # pragma: no cover - useful if it happens to help, but not a big deal
             result.append(f"Created IngestionSubmission object: s3://{self.bundles_bucket}/{SOME_UUID}")
         result.append(f"{uploaded_time} Bundle uploaded to bucket {self.bundles_bucket},"
@@ -1396,7 +1395,8 @@ class Scenario:
                 result.append(wait_line)
         return result
 
-    def make_timeout_lines(self, *, get_attempts=ATTEMPTS_BEFORE_TIMEOUT):
+    @classmethod
+    def make_timeout_lines(cls, *, get_attempts=ATTEMPTS_BEFORE_TIMEOUT):
         # wait_time = self.get_elapsed_time_for_get_attempts(get_attempts)
         # adjusted_scenario = Scenario(start_time=wait_time, wait_time_delta=self.wait_time_delta)
         # time_out_time = adjusted_scenario.get_time_after_wait()
@@ -1477,8 +1477,9 @@ def test_submit_any_ingestion_old_protocol(mock_get_health_page):
                     assert shown.lines == ["Aborting submission."]
 
     def mocked_post(url, auth, data, headers, files, **kwargs):
-        # We only expect requests.post to be called on one particular URL, so this definition is very specialized
-        # mostly just to check that we're being called on what we think so we can return something highly specific
+        assert not kwargs, "The mock named mocked_post did not expect keyword arguments."
+        # We only expect requests.post to be called on one particular URL, so this definition is very specialized,
+        # mostly just to check that we're being called on what we think, so we can return something highly specific
         # with some degree of confidence. -kmp 6-Sep-2020
         assert url.endswith('/submit_for_ingestion')
         assert auth == SOME_AUTH
@@ -1535,6 +1536,7 @@ def test_submit_any_ingestion_old_protocol(mock_get_health_page):
         response_maker = make_alternator(*responses)
 
         def mocked_get(url, auth, **kwargs):
+            assert set(kwargs.keys()) == {'headers'}, "The mock named mocked_get expected only 'headers' among kwargs."
             print("in mocked_get, url=", url, "auth=", auth)
             assert auth == SOME_AUTH
             if url.endswith("/me?format=json"):
@@ -1619,7 +1621,7 @@ def test_submit_any_ingestion_old_protocol(mock_get_health_page):
                                                                                  subfolders=False,
                                                                                  )
                                                         except SystemExit as e:  # pragma: no cover
-                                                            # This is just in case. In fact it's more likely
+                                                            # This is just in case. In fact, it's more likely
                                                             # that a normal 'return' not 'exit' was done.
                                                             assert e.code == 0
 
@@ -1677,7 +1679,7 @@ def test_submit_any_ingestion_old_protocol(mock_get_health_page):
                                                                                  subfolders=False,
                                                                                  )
                                                         except SystemExit as e:  # pragma: no cover
-                                                            # This is just in case. In fact it's more likely
+                                                            # This is just in case. In fact, it's more likely
                                                             # that a normal 'return' not 'exit' was done.
                                                             assert e.code == 0
 
@@ -1725,7 +1727,7 @@ def test_submit_any_ingestion_old_protocol(mock_get_health_page):
                                                                              subfolders=False,
                                                                              )
                                                     except SystemExit as e:  # pragma: no cover
-                                                        # This is just in case. In fact it's more likely
+                                                        # This is just in case. In fact, it's more likely
                                                         # that a normal 'return' not 'exit' was done.
                                                         assert e.code == 0
 
@@ -1884,7 +1886,7 @@ def test_submit_any_ingestion_old_protocol(mock_get_health_page):
                                                                                  subfolders=False,
                                                                                  )
                                                         except SystemExit as e:  # pragma: no cover
-                                                            # This is just in case. In fact it's more likely
+                                                            # This is just in case. In fact, it's more likely
                                                             # that a normal 'return' not 'exit' was done.
                                                             assert e.code == 0
 
@@ -2005,6 +2007,7 @@ def test_submit_any_ingestion_new_protocol(mock_get_health_page):
     expect_datafile_for_mocked_post = True
 
     def mocked_post(url, auth, data=None, json=None, files=None, headers=None, **kwargs):
+        assert not kwargs, "The mock named mocked_post did not expect keyword arguments."
         ignored(data, json)
         content_type = headers and headers.get('Content-type')
         if content_type:
@@ -2035,8 +2038,8 @@ def test_submit_any_ingestion_new_protocol(mock_get_health_page):
                                     ]
                                 })
         elif url.endswith("/submit_for_ingestion"):
-            # We only expect requests.post to be called on one particular URL, so this definition is very specialized
-            # mostly just to check that we're being called on what we think so we can return something highly specific
+            # We only expect requests.post to be called on one particular URL, so this definition is very specialized,
+            # mostly just to check that we're being called on what we think, so we can return something highly specific
             # with some degree of confidence. -kmp 6-Sep-2020
             m = re.match(".*/ingestion-submissions/([a-f0-9-]*)/submit_for_ingestion$", url)
             if m:
@@ -2099,6 +2102,7 @@ def test_submit_any_ingestion_new_protocol(mock_get_health_page):
         response_maker = make_alternator(*responses)
 
         def mocked_get(url, auth, **kwargs):
+            assert set(kwargs.keys()) == {'headers'}, "The mock named mocked_get expected only 'headers' among kwargs."
             print("in mocked_get, url=", url, "auth=", auth)
             assert auth == SOME_AUTH
             if url.endswith("/me?format=json"):
@@ -2184,7 +2188,7 @@ def test_submit_any_ingestion_new_protocol(mock_get_health_page):
                                                                                  no_query=False,
                                                                                  subfolders=False)
                                                         except SystemExit as e:  # pragma: no cover
-                                                            # This is just in case. In fact it's more likely
+                                                            # This is just in case. In fact, it's more likely
                                                             # that a normal 'return' not 'exit' was done.
                                                             assert e.code == 0
 
@@ -2227,6 +2231,7 @@ def test_submit_any_ingestion_new_protocol(mock_get_health_page):
                                                                                ) as mock_upload_file_to_new_uuid:
                                                             def mocked_upload_file_to_new_uuid(filename, schema_name,
                                                                                                auth, **app_args):
+                                                                ignored(app_args)  # not relevant to this test
                                                                 assert filename == SOME_BUNDLE_FILENAME
                                                                 assert schema_name == expected_schema_name
                                                                 assert auth['key'] == SOME_KEY_ID
@@ -2257,7 +2262,7 @@ def test_submit_any_ingestion_new_protocol(mock_get_health_page):
                                                                     submission_protocol=SubmissionProtocol.S3,
                                                                 )
                                                             except SystemExit as e:  # pragma: no cover
-                                                                # This is just in case. In fact it's more likely
+                                                                # This is just in case. In fact, it's more likely
                                                                 # that a normal 'return' not 'exit' was done.
                                                                 assert e.code == 0
 
@@ -2464,7 +2469,7 @@ def test_submit_any_ingestion_new_protocol(mock_get_health_page):
                                                                                  subfolders=False,
                                                                                  )
                                                         except SystemExit as e:  # pragma: no cover
-                                                            # This is just in case. In fact it's more likely
+                                                            # This is just in case. In fact, it's more likely
                                                             # that a normal 'return' not 'exit' was done.
                                                             assert e.code == 0
 
@@ -2806,7 +2811,7 @@ def test_submit_any_ingestion():
         pass
 
     def mocked_resolve_app_args(institution, project, lab, award, app, consortium, submission_center):
-        ignored(institution, project, award, lab)
+        ignored(institution, project, award, lab, consortium, submission_center)  # not relevant to this mock
         assert app == expected_app
         raise StopEarly()
 
@@ -3035,6 +3040,7 @@ expected_schema_name = GENERIC_SCHEMA_TYPE
 def test_upload_file_to_new_uuid():
 
     def mocked_execute_prearranged_upload(filename, upload_credentials, auth, **kwargs):
+        assert not kwargs, "kwargs were not expected for mock of mocked_execute_prearranged_upload"
         assert filename == mocked_good_filename
         assert upload_credentials == mocked_good_upload_credentials
         assert auth == mocked_good_auth
@@ -3116,6 +3122,7 @@ def test_do_app_arg_defaulting():
     default_default_foo = 17
 
     def get_defaulted_foo(foo, user_record, error_if_none=False):
+        ignored(error_if_none)  # not needed for this mock
         return user_record.get('default-foo', default_default_foo) if foo is None else foo
 
     defaulters_for_testing = {

--- a/submit_cgap/tests/test_submission.py
+++ b/submit_cgap/tests/test_submission.py
@@ -30,7 +30,7 @@ from ..submission import (
     _resolve_app_args,  # noQA - yes, a protected member, but we still need to test it
     _post_files_data,  # noQA - again, testing a protected member
     get_defaulted_lab, get_defaulted_award, SubmissionProtocol, compute_file_post_data,
-    upload_file_to_new_uuid, compute_s3_submission_post_data, GENERIC_SCHEMA_TYPE, DEFAULT_APP,
+    upload_file_to_new_uuid, compute_s3_submission_post_data, GENERIC_SCHEMA_TYPE, DEFAULT_APP, summarize_submission,
     get_defaulted_submission_centers, get_defaulted_consortia, do_app_arg_defaulting, check_submit_ingestion,
 )
 from ..utils import FakeResponse, script_catch_errors, ERROR_HERALD
@@ -3194,3 +3194,22 @@ def test_check_submit_ingestion_with_app_None():
                 check_submit_ingestion(uuid='some-uuid', server='some-server', env='some-env', app=None)
             assert KEY_MANAGER.selected_app == APP_FOURFRONT
         assert KEY_MANAGER.selected_app == APP_CGAP
+
+
+def test_summarize_submission():
+
+    # env supplied
+    summary = summarize_submission(uuid='some-uuid', env='some-env', app='some-app')
+    assert summary == "check-submit --app some-app --env some-env some-uuid"
+
+    # server supplied
+    summary = summarize_submission(uuid='some-uuid', server='some-server', app='some-app')
+    assert summary == "check-submit --app some-app --server some-server some-uuid"
+
+    # If both are supplied, env wins.
+    summary = summarize_submission(uuid='some-uuid', server='some-server', env='some-env', app='some-app')
+    assert summary == "check-submit --app some-app --env some-env some-uuid"
+
+    # If neither is supplied, well, that shouldn't really happen, but we'll see this:
+    summary = summarize_submission(uuid='some-uuid', server=None, env=None, app='some-app')
+    assert summary == "check-submit --app some-app some-uuid"

--- a/submit_cgap/tests/test_submission.py
+++ b/submit_cgap/tests/test_submission.py
@@ -31,6 +31,7 @@ from ..submission import (
     _post_files_data,  # noQA - again, testing a protected member
     get_defaulted_lab, get_defaulted_award, SubmissionProtocol, compute_file_post_data,
     upload_file_to_new_uuid, compute_s3_submission_post_data, GENERIC_SCHEMA_TYPE,
+    get_defaulted_submission_centers, get_defaulted_consortia,
 )
 from ..utils import FakeResponse, script_catch_errors, ERROR_HERALD
 
@@ -58,6 +59,12 @@ SOME_KEY_ID, SOME_SECRET = SOME_AUTH
 SOME_INSTITUTION = '/institutions/hms-dbmi/'
 
 SOME_OTHER_INSTITUTION = '/institutions/big-pharma/'
+
+SOME_CONSORTIUM = '/lab/good-consortium/'
+SOME_CONSORTIA = [SOME_CONSORTIUM]
+
+SOME_SUBMISSION_CENTER = '/lab/good-submission-center/'
+SOME_SUBMISSION_CENTERS = [SOME_SUBMISSION_CENTER]
 
 SOME_LAB = '/lab/good-lab/'
 
@@ -2901,6 +2908,52 @@ def test_get_defaulted_award():
     with pytest.raises(Exception) as exc:
         get_defaulted_award(award=None, user_record=make_user_record(), error_if_none=True)
     assert str(exc.value).startswith("Your user profile declares no lab with awards.")
+
+
+def test_get_defaulted_consortia():
+
+    assert get_defaulted_consortia(consortia=SOME_CONSORTIA, user_record='does-not-matter') == SOME_CONSORTIA
+    assert get_defaulted_consortia(consortia=['anything'], user_record='does-not-matter') == ['anything']
+
+    user_record = make_user_record(consortia=[{'@id': SOME_CONSORTIUM}])
+
+    successful_result = get_defaulted_consortia(consortia=None, user_record=user_record)
+
+    print("successful_result=", successful_result)
+
+    assert successful_result == SOME_CONSORTIA
+
+    assert get_defaulted_consortia(consortia=None, user_record=make_user_record()) == []
+    assert get_defaulted_consortia(consortia=None, user_record=make_user_record(),
+                                   error_if_none=False) == []
+
+    with pytest.raises(Exception) as exc:
+        get_defaulted_consortia(consortia=None, user_record=make_user_record(), error_if_none=True)
+    assert str(exc.value).startswith("Your user profile has no consortium")
+
+
+def test_get_defaulted_submission_centers():
+
+    assert get_defaulted_submission_centers(submission_centers=SOME_SUBMISSION_CENTERS,
+                                            user_record='does-not-matter') == SOME_SUBMISSION_CENTERS
+    assert get_defaulted_submission_centers(submission_centers=['anything'],
+                                            user_record='does-not-matter') == ['anything']
+
+    user_record = make_user_record(submission_centers=[{'@id': SOME_SUBMISSION_CENTER}])
+
+    successful_result = get_defaulted_submission_centers(submission_centers=None, user_record=user_record)
+
+    print("successful_result=", successful_result)
+
+    assert successful_result == SOME_SUBMISSION_CENTERS
+
+    assert get_defaulted_submission_centers(submission_centers=None, user_record=make_user_record()) == []
+    assert get_defaulted_submission_centers(submission_centers=None, user_record=make_user_record(),
+                                            error_if_none=False) == []
+
+    with pytest.raises(Exception) as exc:
+        get_defaulted_submission_centers(submission_centers=None, user_record=make_user_record(), error_if_none=True)
+    assert str(exc.value).startswith("Your user profile has no submission center")
 
 
 def test_post_files_data():

--- a/submit_cgap/tests/test_submission.py
+++ b/submit_cgap/tests/test_submission.py
@@ -31,7 +31,7 @@ from ..submission import (
     _post_files_data,  # noQA - again, testing a protected member
     get_defaulted_lab, get_defaulted_award, SubmissionProtocol, compute_file_post_data,
     upload_file_to_new_uuid, compute_s3_submission_post_data, GENERIC_SCHEMA_TYPE,
-    get_defaulted_submission_centers, get_defaulted_consortia, APP_ARG_DEFAULTERS, do_app_arg_defaulting,
+    get_defaulted_submission_centers, get_defaulted_consortia, do_app_arg_defaulting,
 )
 from ..utils import FakeResponse, script_catch_errors, ERROR_HERALD
 

--- a/submit_cgap/tests/test_submission.py
+++ b/submit_cgap/tests/test_submission.py
@@ -1218,7 +1218,7 @@ class Scenario:
         uploaded_time = self.get_time_after_wait()
         result = []
         result.append(f"The server {SOME_SERVER} recognizes you as: J Doe <jdoe@cgap.hms.harvard.edu>")
-        if submission_module.DEBUG_PROTOCOL:
+        if submission_module.DEBUG_PROTOCOL:  # pragma: no cover - useful if it happens to help, but not a big deal
             result.append(f"Created IngestionSubmission object: s3://{self.bundles_bucket}/{SOME_UUID}")
         result.append(f"{uploaded_time} Bundle uploaded to bucket {self.bundles_bucket},"
                       f" assigned uuid {SOME_UUID} for tracking. Awaiting processing...")

--- a/submit_cgap/tests/test_submission.py
+++ b/submit_cgap/tests/test_submission.py
@@ -1322,8 +1322,11 @@ class Scenario:
         return result
 
 
+@mock.patch.object(submission_module, "get_health_page")
 @mock.patch.object(submission_module, "DEBUG_PROTOCOL", False)
-def test_submit_any_ingestion_old_protocol():
+def test_submit_any_ingestion_old_protocol(mock_get_health_page):
+
+    mock_get_health_page.return_value = {HealthPageKey.S3_ENCRYPT_KEY_ID: TEST_ENCRYPT_KEY}
 
     with shown_output() as shown:
         with mock.patch.object(utils_module, "script_catch_errors", script_dont_catch_errors):
@@ -1846,8 +1849,11 @@ def test_submit_any_ingestion_old_protocol():
         assert shown.lines == Scenario.make_timeout_submission_lines()
 
 
+@mock.patch.object(submission_module, "get_health_page")
 @mock.patch.object(submission_module, "DEBUG_PROTOCOL", False)
-def test_submit_any_ingestion_new_protocol():
+def test_submit_any_ingestion_new_protocol(mock_get_health_page):
+
+    mock_get_health_page.return_value = {HealthPageKey.S3_ENCRYPT_KEY_ID: TEST_ENCRYPT_KEY}
 
     with shown_output() as shown:
         with mock.patch.object(utils_module, "script_catch_errors", script_dont_catch_errors):

--- a/submit_cgap/tests/test_submission.py
+++ b/submit_cgap/tests/test_submission.py
@@ -7,7 +7,7 @@ import pytest
 import re
 
 from dcicutils.common import APP_CGAP, APP_FOURFRONT, APP_SMAHT
-from dcicutils.misc_utils import ignored, local_attrs, override_environ, NamedObject
+from dcicutils.misc_utils import ignored, ignorable, local_attrs, override_environ, NamedObject
 from dcicutils.qa_utils import ControlledTime, MockFileSystem, raises_regexp, printed_output
 from dcicutils.s3_utils import HealthPageKey
 from typing import List, Dict
@@ -3142,4 +3142,12 @@ def test_do_app_arg_defaulting():
         args4 = {'bar': 2}
         user4 = {}
         do_app_arg_defaulting(args4, user4)
+        assert args4 == {'bar': 2}
+
+        # If the defaulter returns None, the argument is removed rather than be None
+        default_default_foo = None  # make defaulter return None if default not found on the user
+        ignorable(default_default_foo)  # it gets used in the closure, PyCharm should know
+        args5 = {'foo': None, 'bar': 2}
+        user5 = {}
+        do_app_arg_defaulting(args5, user5)
         assert args4 == {'bar': 2}

--- a/submit_cgap/utils.py
+++ b/submit_cgap/utils.py
@@ -7,6 +7,11 @@ from dcicutils.misc_utils import PRINT, environ_bool
 from json import dumps as json_dumps, loads as json_loads
 
 
+ERASE_LINE = "\033[K"
+TIMESTAMP_PATTERN = "%H:%M:%S"
+TIMESTAMP_REGEXP = "[0-2][0-9]:[0-5][0-9]:[0-5][0-9]"
+
+
 # Programmatic output will use 'show' so that debugging statements using regular 'print' are more easily found.
 def show(*args, with_time: bool = False, same_line: bool = False):
     """
@@ -14,11 +19,13 @@ def show(*args, with_time: bool = False, same_line: bool = False):
 
     :param args: an object to be printed
     :param with_time: a boolean specifying whether to prepend a timestamp
+    :param same_line: a boolean saying whether to do this output in a way that erases the current line
+        and returns to the start of the line without advancing vertically so that subsequent same_line=True
+        requests will erase (and so replace) the current line.
     """
-    ERASE_LINE = "\033[K"
     output = io.StringIO()
     if with_time:
-        hh_mm_ss = str(datetime.datetime.now().strftime("%H:%M:%S"))
+        hh_mm_ss = str(datetime.datetime.now().strftime(TIMESTAMP_PATTERN))
         print(hh_mm_ss, *args, end="", file=output)
     else:
         print(*args, end="", file=output)


### PR DESCRIPTION
This is a SubmitCGAP script which will check the status of a previously run submission. It is useful if the user either kills the submission command (e.g. submit-metadata or submit-ontology) before it is done waiting for the results or if the submission command times out waiting for the results. It is invoked with the submission (GUID) ID. 