### PR TITLE
Some amount of SMaHT support.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,16 @@ Change Log
 ----------
 
 
+4.1.0
+=====
+
+* Support for a check-submission command.
+* Very basic support for SMaHT.
+  * Commands can now take ``--app smaht`` (which will use ``~/.smaht-keys.json``)
+  * submit-ontology takes ``--consortium`` and ``submission_center`` arguments.
+  * Some other functionality may still be missing. Send email if you're missing something you need.
+
+
 4.0.0
 =====
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -471,14 +471,14 @@ tox = ["tox"]
 
 [[package]]
 name = "dcicutils"
-version = "7.4.1"
+version = "7.6.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 category = "main"
 optional = false
 python-versions = ">=3.7,<3.10"
 files = [
-    {file = "dcicutils-7.4.1-py3-none-any.whl", hash = "sha256:eafacedee6845387cff54ef1760a43d264fc52422af5259b3cc0f97d580c3c25"},
-    {file = "dcicutils-7.4.1.tar.gz", hash = "sha256:9c939a450e4c5446922188fa7e3b9f7fb92e698a40f96af560dc7b52bbc7668c"},
+    {file = "dcicutils-7.6.0-py3-none-any.whl", hash = "sha256:043d700aab91cc20b08acad07948eeafde21504d0fcc37813bc82cc220e28889"},
+    {file = "dcicutils-7.6.0.tar.gz", hash = "sha256:2944c40c907d26154ad1865b52434b52c66e12b548938f90fe32b061d81d380f"},
 ]
 
 [package.dependencies]
@@ -1610,4 +1610,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7.0,<3.10"
-content-hash = "7722b539205485457bf3baf620c745f2ed56f7698895a8e2e6b77afb0bdcb59c"
+content-hash = "97f0846571152517d2ec02a4c7a3e4dcc415d23aa90a6c6f2759df286db25737"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "submit_cgap"
-version = "4.0.0"
+version = "4.1.0"
 description = "Support for uploading file submissions to the Clinical Genomics Analysis Platform (CGAP)."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -48,7 +48,7 @@ python = ">=3.7.0,<3.10"
 
 awscli = "^1.27.79"
 # boto3 = "^1.26.79"
-dcicutils = "^7.4.0"
+dcicutils = "^7.6.0"
 requests = "^2.28.2"
 
 [tool.poetry.dev-dependencies]
@@ -81,16 +81,16 @@ sphinx-rtd-theme = ">=1.2.0"
 
 [tool.poetry.scripts]
 
+check-submission= "submit_cgap.scripts.check_submission:main"
 make-sample-fastq-file = "submit_cgap.scripts.make_sample_fastq_file:main"
 publish-to-pypi = "dcicutils.scripts.publish_to_pypi:main"
 resume-uploads = "submit_cgap.scripts.resume_uploads:main"
 show-submission-info = "submit_cgap.scripts.show_submission_info:main"
 show-upload-info = "submit_cgap.scripts.show_upload_info:main"
-submit-metadata-bundle = "submit_cgap.scripts.submit_metadata_bundle:main"
-upload-item-data = "submit_cgap.scripts.upload_item_data:main"
 submit-genelist = "submit_cgap.scripts.submit_genelist:main"
+submit-metadata-bundle = "submit_cgap.scripts.submit_metadata_bundle:main"
 submit-ontology = "submit_cgap.scripts.submit_ontology:main"
-check-submission= "submit_cgap.scripts.check_submission:main"
+upload-item-data = "submit_cgap.scripts.upload_item_data:main"
 
 [tool.coverage.report]
 

--- a/submit_cgap/base.py
+++ b/submit_cgap/base.py
@@ -1,8 +1,8 @@
 import contextlib
 import os
 
-from dcicutils.common import OrchestratedApp, APP_CGAP, APP_FOURFRONT, ORCHESTRATED_APPS
-from dcicutils.creds_utils import KeyManager, CGAPKeyManager, FourfrontKeyManager
+from dcicutils.common import OrchestratedApp, APP_CGAP, APP_FOURFRONT, APP_SMAHT, ORCHESTRATED_APPS
+from dcicutils.creds_utils import KeyManager, CGAPKeyManager, FourfrontKeyManager, SMaHTKeyManager
 from dcicutils.exceptions import InvalidParameterError
 
 
@@ -15,13 +15,22 @@ PRODUCTION_SERVER = 'https://cgap.hms.harvard.edu'
 PRODUCTION_ENV = 'fourfront-cgap'
 
 DEFAULT_ENV_VAR = 'SUBMITCGAP_ENV'
+DEFAULT_APP_VAR = 'SUBMITCGAP_APP'
+
+DEFAULT_DEFAULT_ENV = PRODUCTION_ENV
+DEFAULT_DEFAULT_APP = APP_CGAP
 
 
-def _compute_default_env():
-    return os.environ.get(DEFAULT_ENV_VAR, PRODUCTION_ENV)
+def _compute_default_env():  # factored out as a function for testing
+    return os.environ.get(DEFAULT_ENV_VAR, DEFAULT_DEFAULT_ENV)
+
+
+def _compute_default_app():  # factored out as a function for testing
+    return os.environ.get(DEFAULT_APP_VAR, DEFAULT_DEFAULT_APP)
 
 
 DEFAULT_ENV = _compute_default_env()
+DEFAULT_APP = _compute_default_app()
 
 
 class GenericKeyManager:
@@ -32,14 +41,17 @@ class GenericKeyManager:
     def __init__(self):
         self._cgap_key_manager: KeyManager = CGAPKeyManager()
         self._fourfront_key_manager: KeyManager = FourfrontKeyManager()
+        self._smaht_key_manager: KeyManager = SMaHTKeyManager()
         self._key_manager: KeyManager = self._cgap_key_manager
-        self._selected_app = APP_CGAP
+        self._selected_app = DEFAULT_APP
 
     def select_app(self, app: OrchestratedApp):
         if app == APP_CGAP:
             self._key_manager = self._cgap_key_manager
         elif app == APP_FOURFRONT:
             self._key_manager = self._fourfront_key_manager
+        elif app == APP_SMAHT:
+            self._key_manager = self._smaht_key_manager
         else:
             raise InvalidParameterError(parameter='app', value=app, options=ORCHESTRATED_APPS)
         self._selected_app = app

--- a/submit_cgap/scripts/check_submission.py
+++ b/submit_cgap/scripts/check_submission.py
@@ -1,6 +1,6 @@
 import argparse
 from dcicutils.common import ORCHESTRATED_APPS
-from dcicutils.env_utils import EnvUtils
+from ..base import DEFAULT_APP
 from ..submission import check_submit_ingestion
 from ..utils import script_catch_errors
 
@@ -8,13 +8,7 @@ from ..utils import script_catch_errors
 EPILOG = __doc__
 
 
-def default_app_for_check_submission():
-    EnvUtils.init()
-    return EnvUtils.app_name()
-
-
 def main(simulated_args_for_testing=None):
-    default_app = default_app_for_check_submission()
 
     parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is invalid
         description="Check previously submitted submission.",
@@ -22,8 +16,8 @@ def main(simulated_args_for_testing=None):
         formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument('submission_uuid', help='uuid of previously submitted submission.')
-    parser.add_argument('--app', choices=ORCHESTRATED_APPS, default=default_app,
-                        help=f"An application (default {default_app!r}. Only for debugging."
+    parser.add_argument('--app', choices=ORCHESTRATED_APPS, default=DEFAULT_APP,
+                        help=f"An application (default {DEFAULT_APP!r}. Only for debugging."
                              f" Normally this should not be given.")
     parser.add_argument('--server', '-s', help="an http or https address of the server to use", default=None)
     parser.add_argument('--env', '-e', help="a CGAP beanstalk environment name for the server to use", default=None)

--- a/submit_cgap/scripts/submit_ontology.py
+++ b/submit_cgap/scripts/submit_ontology.py
@@ -21,6 +21,10 @@ def main(simulated_args_for_testing=None):
     parser.add_argument('ontology_filename', help='a file of ontology data')
     parser.add_argument('--lab', '-l', '-L', help='lab identifier', default=None)
     parser.add_argument('--award', '-a', help='award identifier', default=None)
+    parser.add_argument('--consortium', '-c', default=None,
+                        help='consortium identifier (comma-separated if several)')
+    parser.add_argument('--submission-center', '-sc', default=None,
+                        help='submission center intifier (comma-separated if several)')
     parser.add_argument('--server', '-s', help="an http or https address of the server to use", default=None)
     parser.add_argument('--env', '-e', help="a CGAP beanstalk environment name for the server to use", default=None)
     parser.add_argument('--validate-only', '-v', action="store_true",
@@ -42,6 +46,8 @@ def main(simulated_args_for_testing=None):
                 ingestion_type='ontology',
                 lab=args.lab,
                 award=args.award,
+                consortium=args.consortium,
+                submission_center=args.submission_center,
                 server=args.server,
                 env=args.env,
                 validate_only=args.validate_only,

--- a/submit_cgap/tests/test_check_submission.py
+++ b/submit_cgap/tests/test_check_submission.py
@@ -2,7 +2,8 @@ from unittest import mock
 
 from dcicutils.common import ORCHESTRATED_APPS
 from dcicutils.misc_utils import ignored
-from ..scripts.check_submission import main as check_submission_main, default_app_for_check_submission
+from ..base import DEFAULT_APP
+from ..scripts.check_submission import main as check_submission_main
 from ..scripts import check_submission as check_submission_module
 from .testing_helpers import system_exit_expected
 
@@ -11,8 +12,6 @@ SAMPLE_GUID = '1f199b61-e7a1-4c2a-9599-cfc64f51dab7'
 
 
 def test_check_submission_script():
-
-    default_app = default_app_for_check_submission()
 
     def test_it(args_in, expect_exit_code, expect_called, expect_call_args=None):
         ignored(expect_call_args)
@@ -26,13 +25,13 @@ def test_check_submission_script():
     test_it(args_in=[SAMPLE_GUID], expect_exit_code=0, expect_called=True,
             expect_call_args={
                 'submission_uuid': SAMPLE_GUID,
-                'app': default_app,
+                'app': DEFAULT_APP,
                 'server': None,
                 'env': None,
             })
     sample_app = None
     for app in ORCHESTRATED_APPS:
-        if app != default_app:
+        if app != DEFAULT_APP:
             sample_app = app
     assert sample_app, "sample_app did not get properly set."
     sample_server = 'https://cgap-foo'
@@ -42,7 +41,7 @@ def test_check_submission_script():
             expect_called=True,
             expect_call_args={
                 'submission_uuid': SAMPLE_GUID,
-                'app': default_app,
+                'app': DEFAULT_APP,
                 'server': sample_server,
                 'env': None,
             })
@@ -60,7 +59,7 @@ def test_check_submission_script():
             expect_called=True,
             expect_call_args={
                 'submission_uuid': SAMPLE_GUID,
-                'app': default_app,
+                'app': DEFAULT_APP,
                 'server': None,
                 'env': sample_env,
             })


### PR DESCRIPTION
This is a layered PR, proposing an adjustment to [PR #39](https://github.com/dbmi-bgm/SubmitCGAP/pull/41).

The primary goal here was to get defaulting of the `--app` arg to _not_ be to `fourfront`, but also not to get tangled up in `EnvUtils` support. The default is changed to `APP_CGAP` (i.e., `'cgap'`) and can be changed by setting the `SUBMITCGAP_APP` environment variable (see changes to `base.py`).

Along the way, we add very basic support for SMaHT. Probably more will be needed later, but this adds:

  * Commands can now take `--app smaht` (which will use `~/.smaht-keys.json`), though I think only `submit-ontology` will do something interesting with that since other commands would need addition of `--consortium` and `--submission_center` if those args are meaningful for them. (I wasn't sure they were, so didn't rush to add them.)

  * `submit-ontology` takes `--consortium` and `submission_center` arguments, in case `--app smaht` is given.

